### PR TITLE
Fix car management display and delete issues

### DIFF
--- a/RentACar.Infrastructure/Data/Repository/CarRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/CarRepository.cs
@@ -44,7 +44,9 @@ namespace RentACar.Infrastructure.Data.Repositories
 
         public async Task<List<Car>> SearchByFilterAsync(string? modelName = null, int? modelYear = null, int? categoryId = null, bool? isAvailable = null)
         {
-            var query = _dbContext.Cars.AsQueryable();
+            var query = _dbContext.Cars
+                .Include(c => c.Category)
+                .AsQueryable();
 
             if (!string.IsNullOrEmpty(modelName))
             {

--- a/RentACar.Web/Controllers/CarController.cs
+++ b/RentACar.Web/Controllers/CarController.cs
@@ -104,9 +104,9 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> DeleteConfirmed(int id)
+        public async Task<IActionResult> DeleteConfirmed(int carId)
         {
-            await _carRepository.DeleteAsync(id);
+            await _carRepository.DeleteAsync(carId);
             return RedirectToAction(nameof(Index));
         }
 

--- a/RentACar.Web/Views/ControlPanel/Car/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Car/Index.cshtml
@@ -89,7 +89,7 @@
                                     <i class="fas fa-times text-danger"></i>
                                 }
                             </td>
-                            <td>@car.CategoryId</td>
+                            <td>@car.CategoryName</td>
                             <td>
                                 <a href="#" class="text-warning me-2 edit-car" data-id="@car.CarId"><i class="fas fa-pencil-alt"></i></a>
                                 <a href="#" class="text-danger delete-car" data-id="@car.CarId"><i class="fas fa-trash"></i></a>

--- a/RentACar.Web/Views/ControlPanel/Car/_CarFormPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Car/_CarFormPartial.cshtml
@@ -1,5 +1,6 @@
 @model RentACar.Application.DTOs.CarDto
 <form asp-action="@(Model.CarId == 0 ? "Add" : "Edit")" method="post">
+    <input type="hidden" asp-for="CarId" />
     <div class="mb-3">
         <label class="form-label">Plate Number</label>
         <input asp-for="PlateNumber" class="form-control" />

--- a/RentACar.Web/Views/ControlPanel/Car/_DeleteCarPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Car/_DeleteCarPartial.cshtml
@@ -1,6 +1,6 @@
 @model RentACar.Application.DTOs.CarDto
 <form asp-action="DeleteConfirmed" method="post">
-    <input type="hidden" asp-for="CarId" />
+    <input type="hidden" name="carId" value="@Model.CarId" />
     <p>Are you sure you want to delete car <strong>@Model.PlateNumber</strong>?</p>
     <button type="submit" class="btn btn-danger">Delete</button>
     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>


### PR DESCRIPTION
## Summary
- load car category names for filter results
- keep CarId in car form for edits
- fix delete car form name binding
- update controller to use `carId` param
- show category name in car list

## Testing
- `dotnet build RentACar.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c00f3f48321a4028ce7c2df01ea