### PR TITLE
Add customer management page and API

### DIFF
--- a/RentACar.Application/DTOs/CustomerDocumentsDto.cs
+++ b/RentACar.Application/DTOs/CustomerDocumentsDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Application.DTOs
+{
+    public class CustomerDocumentsDto
+    {
+        public byte[]? DrivingLicenseFront { get; set; }
+        public byte[]? DrivingLicenseBack { get; set; }
+        public byte[]? NationalIdfront { get; set; }
+        public byte[]? NationalIdback { get; set; }
+    }
+}

--- a/RentACar.Application/DTOs/CustomerDto.cs
+++ b/RentACar.Application/DTOs/CustomerDto.cs
@@ -18,6 +18,7 @@ namespace RentACar.Application.DTOs
         public string? Address { get; set; }
         public string Email { get; internal set; }
         public string username { get; internal set; }
+        public string? PhoneNumber { get; set; }
     }
     public class CustomerCreateDTO
     {

--- a/RentACar.Application/DTOs/CustomerDto.cs
+++ b/RentACar.Application/DTOs/CustomerDto.cs
@@ -8,7 +8,7 @@ namespace RentACar.Application.DTOs
         [Required]
         [MaxLength(50)]
         public string Name { get; set; }
-        public string aspNetUserId { get; set; }
+        public string? aspNetUserId { get; set; }
         public bool IsVerified { get; set; }
         public byte[]? DrivingLicenseFront { get; set; }
         public byte[]? DrivingLicenseBack { get; set; }
@@ -16,8 +16,8 @@ namespace RentACar.Application.DTOs
         public byte[]? NationalIdback { get; set; }
         public bool Isactive { get; set; }
         public string? Address { get; set; }
-        public string Email { get; internal set; }
-        public string username { get; internal set; }
+        public string Email { get; set; }
+        public string username { get; set; }
         public string? PhoneNumber { get; set; }
     }
     public class CustomerCreateDTO

--- a/RentACar.Application/Managers/CustomerManager.cs
+++ b/RentACar.Application/Managers/CustomerManager.cs
@@ -221,6 +221,19 @@ namespace RentACar.Application.Managers
             var result = await _userManager.ResetPasswordAsync(user, token, newPassword);
             return result.Succeeded;
         }
+
+        public async Task UpdateCustomerDocuments(int customerId, CustomerDocumentsDto docs)
+        {
+            if (docs.DrivingLicenseFront != null && docs.DrivingLicenseBack != null)
+            {
+                await UpdateCustomerDrivingLicense(customerId, docs.DrivingLicenseFront, docs.DrivingLicenseBack);
+            }
+
+            if (docs.NationalIdfront != null && docs.NationalIdback != null)
+            {
+                await UpdateCustomerNationalId(customerId, docs.NationalIdfront, docs.NationalIdback);
+            }
+        }
     }
 
     public class CustomerProfile : Profile

--- a/RentACar.Infrastructure/Data/Repository/CustomerRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/CustomerRepository.cs
@@ -19,17 +19,24 @@ namespace RentACar.Infrastructure.Repositories
 
         public async Task<Customer?> GetByIdAsync(int id)
         {
-            return await _dbContext.Set<Customer>().FindAsync(id);
+            return await _dbContext.Set<Customer>()
+                                   .Include(c => c.User)
+                                   .FirstOrDefaultAsync(c => c.UserId == id);
         }
 
         public async Task<List<Customer>> GetAllAsync()
         {
-            return await _dbContext.Set<Customer>().ToListAsync();
+            return await _dbContext.Set<Customer>()
+                                   .Include(c => c.User)
+                                   .ToListAsync();
         }
 
         public async Task<List<Customer>> FindByNameAsync(string name)
         {
-            return await _dbContext.Set<Customer>().Where(c => c.Name.Contains(name)).ToListAsync();
+            return await _dbContext.Set<Customer>()
+                                   .Include(c => c.User)
+                                   .Where(c => c.Name.Contains(name))
+                                   .ToListAsync();
         }
 
         public async Task AddAsync(Customer customer)
@@ -57,6 +64,7 @@ namespace RentACar.Infrastructure.Repositories
         public async Task<Customer?> GetByIdAsync(string aspNetUserId)
         {
             var customer = await _dbContext.Set<Customer>()
+                                           .Include(c => c.User)
                                            .FirstOrDefaultAsync(c => c.aspNetUserId == aspNetUserId);
             return customer;
         }

--- a/RentACar.Web/Controllers/CustomerController.cs
+++ b/RentACar.Web/Controllers/CustomerController.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using RentACar.Application.DTOs;
+using RentACar.Application.Managers;
+
+namespace RentACar.Web.Controllers
+{
+    [Authorize(Roles = "Admin,Employee")]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CustomerController : Controller
+    {
+        private readonly CustomerManager _customerManager;
+        private readonly IMapper _mapper;
+
+        public CustomerController(CustomerManager customerManager, IMapper mapper)
+        {
+            _customerManager = customerManager;
+            _mapper = mapper;
+        }
+
+        [HttpGet("~/Customer")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult Index()
+        {
+            return View("~/Views/ControlPanel/Customer/Index.cshtml");
+        }
+
+        [HttpGet("~/Customer/Add")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult AddForm()
+        {
+            return PartialView("~/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml", new CustomerDTO { Isactive = true });
+        }
+
+        [HttpGet("~/Customer/Edit/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> EditForm(int id)
+        {
+            var customer = await _customerManager.GetCustomerById(id);
+            if (customer == null) return NotFound();
+            return PartialView("~/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml", customer);
+        }
+
+        [HttpGet("~/Customer/Delete/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> DeleteForm(int id)
+        {
+            var customer = await _customerManager.GetCustomerById(id);
+            if (customer == null) return NotFound();
+            return PartialView("~/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml", customer);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CustomerDTO>>> Get([FromQuery] string? search, [FromQuery] bool? verified, [FromQuery] bool? active)
+        {
+            var customers = await _customerManager.GetAllCustomers();
+            if (!string.IsNullOrEmpty(search))
+            {
+                customers = customers.Where(c => (c.Name != null && c.Name.Contains(search, System.StringComparison.OrdinalIgnoreCase)) || c.UserId.ToString() == search).ToList();
+            }
+            if (verified.HasValue)
+                customers = customers.Where(c => c.IsVerified == verified.Value).ToList();
+            if (active.HasValue)
+                customers = customers.Where(c => c.Isactive == active.Value).ToList();
+            return Ok(customers);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CustomerDTO>> Get(int id)
+        {
+            var customer = await _customerManager.GetCustomerById(id);
+            if (customer == null) return NotFound();
+            return Ok(customer);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CustomerDTO>> Create([FromBody] CustomerCreateDTO dto)
+        {
+            var created = await _customerManager.CreateCustomer(dto);
+            if (created == null) return BadRequest();
+            return CreatedAtAction(nameof(Get), new { id = created.UserId }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, [FromBody] CustomerDTO dto)
+        {
+            if (id != dto.UserId) return BadRequest();
+            await _customerManager.UpdateCustomer(dto);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            await _customerManager.DeleteCustomer(id);
+            return NoContent();
+        }
+
+        [HttpPost("{id}/reset-password")]
+        public async Task<IActionResult> ResetPassword(int id)
+        {
+            var success = await _customerManager.ResetPassword(id, "C@c123456");
+            if (!success) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/RentACar.Web/Controllers/CustomerController.cs
+++ b/RentACar.Web/Controllers/CustomerController.cs
@@ -55,6 +55,15 @@ namespace RentACar.Web.Controllers
             return PartialView("~/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml", customer);
         }
 
+        [HttpGet("~/Customer/Documents/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> DocumentsForm(int id)
+        {
+            var customer = await _customerManager.GetCustomerById(id);
+            if (customer == null) return NotFound();
+            return PartialView("~/Views/ControlPanel/Customer/_CustomerDocumentsPartial.cshtml", customer);
+        }
+
         [HttpGet]
         public async Task<ActionResult<IEnumerable<CustomerDTO>>> Get([FromQuery] string? search, [FromQuery] bool? verified, [FromQuery] bool? active)
         {
@@ -106,6 +115,13 @@ namespace RentACar.Web.Controllers
         {
             var success = await _customerManager.ResetPassword(id, "C@c123456");
             if (!success) return NotFound();
+            return NoContent();
+        }
+
+        [HttpPut("{id}/documents")]
+        public async Task<IActionResult> UpdateDocuments(int id, [FromBody] CustomerDocumentsDto dto)
+        {
+            await _customerManager.UpdateCustomerDocuments(id, dto);
             return NoContent();
         }
     }

--- a/RentACar.Web/Views/ControlPanel/Customer/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/Index.cshtml
@@ -1,0 +1,146 @@
+@{
+    ViewData["Title"] = "Customers";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/customers.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    <div class="customer-container container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <a href="../ControlPanel" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width:40px;height:40px" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <h2 class="flex-grow-1 text-center m-0">Manage Customers</h2>
+            <div style="width:40px;"></div>
+        </div>
+        <form id="filterForm" class="row g-2 mb-4 align-items-end">
+            <div class="col">
+                <label class="form-label">Search</label>
+                <input type="text" name="search" class="form-control" placeholder="Name or ID" />
+            </div>
+            <div class="col">
+                <label class="form-label">Verified</label>
+                <select name="verified" class="form-select">
+                    <option value="">Any</option>
+                    <option value="true">Verified</option>
+                    <option value="false">Not Verified</option>
+                </select>
+            </div>
+            <div class="col">
+                <label class="form-label">Active</label>
+                <select name="active" class="form-select">
+                    <option value="">Any</option>
+                    <option value="true">Active</option>
+                    <option value="false">Inactive</option>
+                </select>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-secondary">Filter</button>
+            </div>
+            <div class="col-auto ms-auto">
+                <button type="button" id="addCustomer" class="btn btn-primary"><i class="fas fa-plus me-1"></i>Add Customer</button>
+            </div>
+        </form>
+        <div class="mb-3">
+            <input type="text" id="tableSearch" class="form-control" placeholder="Search table..." />
+        </div>
+        <div class="table-responsive">
+            <table id="customerTable" class="table table-striped table-dark align-middle">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Username</th>
+                        <th>Email</th>
+                        <th>Phone</th>
+                        <th>Verified</th>
+                        <th>Active</th>
+                        <th>Address</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="customerRows"></tbody>
+            </table>
+        </div>
+    </div>
+    <div id="customerModalPlaceholder"></div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        async function loadCustomers() {
+            const params = new URLSearchParams(new FormData(document.getElementById('filterForm')));
+            const res = await fetch('/api/Customer?' + params.toString());
+            const data = await res.json();
+            const tbody = document.getElementById('customerRows');
+            tbody.innerHTML = '';
+            data.forEach(c => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${c.name}</td>
+                    <td>${c.username}</td>
+                    <td>${c.email}</td>
+                    <td>${c.phoneNumber ?? ''}</td>
+                    <td class="text-center">${c.isVerified ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}</td>
+                    <td class="text-center">${c.isactive ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}</td>
+                    <td>${c.address ?? ''}</td>
+                    <td>
+                        <a href="#" class="text-warning me-2 edit-customer" data-id="${c.userId}"><i class="fas fa-pencil-alt"></i></a>
+                        <a href="#" class="text-danger delete-customer" data-id="${c.userId}"><i class="fas fa-trash"></i></a>
+                        <a href="#" class="text-info reset-pass" data-id="${c.userId}" title="Reset Password"><i class="fas fa-key"></i></a>
+                    </td>`;
+                tbody.appendChild(row);
+            });
+        }
+        async function loadModal(url) {
+            const res = await fetch(url);
+            const html = await res.text();
+            const placeholder = document.getElementById('customerModalPlaceholder');
+            placeholder.innerHTML = html;
+            placeholder.querySelectorAll('script').forEach(scr => {
+                const s = document.createElement('script');
+                s.textContent = scr.textContent;
+                document.body.appendChild(s);
+                document.body.removeChild(s);
+            });
+            const modalEl = placeholder.querySelector('.modal');
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+            loadCustomers();
+            document.getElementById('filterForm').addEventListener('submit', e => { e.preventDefault(); loadCustomers(); });
+            document.getElementById('addCustomer').addEventListener('click', () => loadModal('/Customer/Add'));
+            document.getElementById('customerRows').addEventListener('click', async e => {
+                const edit = e.target.closest('.edit-customer');
+                const del = e.target.closest('.delete-customer');
+                const reset = e.target.closest('.reset-pass');
+                if (edit) {
+                    e.preventDefault();
+                    loadModal('/Customer/Edit/' + edit.dataset.id);
+                } else if (del) {
+                    e.preventDefault();
+                    loadModal('/Customer/Delete/' + del.dataset.id);
+                } else if (reset) {
+                    e.preventDefault();
+                    if (confirm('Reset password for this customer?')) {
+                        await fetch('/api/Customer/' + reset.dataset.id + '/reset-password', { method: 'POST' });
+                    }
+                }
+            });
+            document.getElementById('tableSearch').addEventListener('keyup', function () {
+                const value = this.value.toLowerCase();
+                document.querySelectorAll('#customerTable tbody tr').forEach(tr => {
+                    tr.style.display = tr.textContent.toLowerCase().includes(value) ? '' : 'none';
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Customer/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/Index.cshtml
@@ -94,6 +94,7 @@
                         <a href="#" class="text-warning me-2 edit-customer" data-id="${c.userId}"><i class="fas fa-pencil-alt"></i></a>
                         <a href="#" class="text-danger delete-customer" data-id="${c.userId}"><i class="fas fa-trash"></i></a>
                         <a href="#" class="text-info reset-pass" data-id="${c.userId}" title="Reset Password"><i class="fas fa-key"></i></a>
+                        <a href="#" class="text-success ms-2 view-docs" data-id="${c.userId}" title="Documents"><i class="fas fa-file-image"></i></a>
                     </td>`;
                 tbody.appendChild(row);
             });
@@ -121,6 +122,7 @@
                 const edit = e.target.closest('.edit-customer');
                 const del = e.target.closest('.delete-customer');
                 const reset = e.target.closest('.reset-pass');
+                const docs = e.target.closest('.view-docs');
                 if (edit) {
                     e.preventDefault();
                     loadModal('/Customer/Edit/' + edit.dataset.id);
@@ -132,6 +134,9 @@
                     if (confirm('Reset password for this customer?')) {
                         await fetch('/api/Customer/' + reset.dataset.id + '/reset-password', { method: 'POST' });
                     }
+                } else if (docs) {
+                    e.preventDefault();
+                    loadModal('/Customer/Documents/' + docs.dataset.id);
                 }
             });
             document.getElementById('tableSearch').addEventListener('keyup', function () {

--- a/RentACar.Web/Views/ControlPanel/Customer/_CustomerDocumentsPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/_CustomerDocumentsPartial.cshtml
@@ -1,0 +1,81 @@
+@model RentACar.Application.DTOs.CustomerDTO
+<div class="modal fade" id="customerDocsModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">Customer Documents</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="docsForm">
+                    <input type="hidden" name="customerId" value="@Model.UserId" />
+                    <div class="row g-3">
+                        <div class="col-md-6 text-center">
+                            <label class="form-label">Driving License Front</label>
+                            @if (Model.DrivingLicenseFront != null)
+                            {
+                                <img src="data:image/png;base64,@Convert.ToBase64String(Model.DrivingLicenseFront)" class="img-fluid mb-2" />
+                            }
+                            <input type="file" name="DrivingLicenseFront" class="form-control" />
+                        </div>
+                        <div class="col-md-6 text-center">
+                            <label class="form-label">Driving License Back</label>
+                            @if (Model.DrivingLicenseBack != null)
+                            {
+                                <img src="data:image/png;base64,@Convert.ToBase64String(Model.DrivingLicenseBack)" class="img-fluid mb-2" />
+                            }
+                            <input type="file" name="DrivingLicenseBack" class="form-control" />
+                        </div>
+                        <div class="col-md-6 text-center">
+                            <label class="form-label">National ID Front</label>
+                            @if (Model.NationalIdfront != null)
+                            {
+                                <img src="data:image/png;base64,@Convert.ToBase64String(Model.NationalIdfront)" class="img-fluid mb-2" />
+                            }
+                            <input type="file" name="NationalIdfront" class="form-control" />
+                        </div>
+                        <div class="col-md-6 text-center">
+                            <label class="form-label">National ID Back</label>
+                            @if (Model.NationalIdback != null)
+                            {
+                                <img src="data:image/png;base64,@Convert.ToBase64String(Model.NationalIdback)" class="img-fluid mb-2" />
+                            }
+                            <input type="file" name="NationalIdback" class="form-control" />
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" id="saveDocs" class="btn btn-primary">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    async function fileToBase64(file) {
+        const buffer = await file.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        bytes.forEach(b => binary += String.fromCharCode(b));
+        return btoa(binary);
+    }
+    document.getElementById('saveDocs').addEventListener('click', async function () {
+        const form = document.getElementById('docsForm');
+        const files = form.elements;
+        const data = {
+            drivingLicenseFront: files['DrivingLicenseFront'].files[0] ? await fileToBase64(files['DrivingLicenseFront'].files[0]) : null,
+            drivingLicenseBack: files['DrivingLicenseBack'].files[0] ? await fileToBase64(files['DrivingLicenseBack'].files[0]) : null,
+            nationalIdfront: files['NationalIdfront'].files[0] ? await fileToBase64(files['NationalIdfront'].files[0]) : null,
+            nationalIdback: files['NationalIdback'].files[0] ? await fileToBase64(files['NationalIdback'].files[0]) : null
+        };
+        const id = form.querySelector('[name="customerId"]').value;
+        await fetch('/api/Customer/' + id + '/documents', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        const modalEl = document.getElementById('customerDocsModal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+    });
+</script>

--- a/RentACar.Web/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml
@@ -1,0 +1,85 @@
+@model RentACar.Application.DTOs.CustomerDTO
+<div class="modal fade" id="customerFormModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">@((Model.UserId == 0) ? "Add Customer" : "Edit Customer")</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="customerForm">
+                    <input type="hidden" asp-for="UserId" />
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input asp-for="Name" class="form-control" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Email</label>
+                        <input asp-for="Email" class="form-control" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Username</label>
+                        <input asp-for="username" class="form-control" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Phone Number</label>
+                        <input asp-for="PhoneNumber" class="form-control" />
+                    </div>
+                    @if (Model.UserId == 0)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label">Password</label>
+                            <input type="password" name="Password" class="form-control" />
+                        </div>
+                    }
+                    <div class="mb-3">
+                        <label class="form-label">Address</label>
+                        <input asp-for="Address" class="form-control" />
+                    </div>
+                    <div class="form-check mb-3">
+                        <input asp-for="IsVerified" class="form-check-input" />
+                        <label class="form-check-label" asp-for="IsVerified">Verified</label>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input asp-for="Isactive" class="form-check-input" />
+                        <label class="form-check-label" asp-for="Isactive">Active</label>
+                    </div>
+                    <button type="submit" class="btn btn-primary">@(Model.UserId == 0 ? "Add" : "Save")</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById('customerForm').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const form = e.target;
+        const f = form.elements;
+        const data = {
+            userId: parseInt(form.querySelector('[name="UserId"]').value || '0'),
+            name: f['Name'].value,
+            email: f['Email'].value,
+            username: f['username'].value,
+            phoneNumber: f['PhoneNumber'].value,
+            address: f['Address'].value,
+            isVerified: form.querySelector('[name="IsVerified"]').checked,
+            isactive: form.querySelector('[name="Isactive"]').checked
+        };
+        let url = '/api/Customer';
+        let method = 'POST';
+        if (data.userId) {
+            url += '/' + data.userId;
+            method = 'PUT';
+        } else {
+            data.password = f['Password'].value;
+        }
+        await fetch(url, {
+            method: method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        const modalEl = form.closest('.modal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+        if (window.loadCustomers) loadCustomers();
+    });
+</script>

--- a/RentACar.Web/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/_CustomerFormPartial.cshtml
@@ -31,6 +31,22 @@
                             <label class="form-label">Password</label>
                             <input type="password" name="Password" class="form-control" />
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label">Driving License Front</label>
+                            <input type="file" name="DrivingLicenseFront" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Driving License Back</label>
+                            <input type="file" name="DrivingLicenseBack" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">National ID Front</label>
+                            <input type="file" name="NationalIdfront" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">National ID Back</label>
+                            <input type="file" name="NationalIdback" class="form-control" />
+                        </div>
                     }
                     <div class="mb-3">
                         <label class="form-label">Address</label>
@@ -51,6 +67,13 @@
     </div>
 </div>
 <script>
+    async function fileToBase64(file) {
+        const buffer = await file.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        bytes.forEach(b => binary += String.fromCharCode(b));
+        return btoa(binary);
+    }
     document.getElementById('customerForm').addEventListener('submit', async function (e) {
         e.preventDefault();
         const form = e.target;
@@ -72,6 +95,10 @@
             method = 'PUT';
         } else {
             data.password = f['Password'].value;
+            data.drivingLicenseFront = f['DrivingLicenseFront'].files[0] ? await fileToBase64(f['DrivingLicenseFront'].files[0]) : null;
+            data.drivingLicenseBack = f['DrivingLicenseBack'].files[0] ? await fileToBase64(f['DrivingLicenseBack'].files[0]) : null;
+            data.nationalIdfront = f['NationalIdfront'].files[0] ? await fileToBase64(f['NationalIdfront'].files[0]) : null;
+            data.nationalIdback = f['NationalIdback'].files[0] ? await fileToBase64(f['NationalIdback'].files[0]) : null;
         }
         await fetch(url, {
             method: method,

--- a/RentACar.Web/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml
@@ -1,0 +1,31 @@
+@model RentACar.Application.DTOs.CustomerDTO
+<div class="modal fade" id="deleteCustomerModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">Delete Customer</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="deleteCustomerForm">
+                <div class="modal-body">
+                    <input type="hidden" name="customerId" value="@Model.UserId" />
+                    <p>Are you sure you want to delete customer <strong>@Model.Name</strong>?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById('deleteCustomerForm').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const id = this.querySelector('[name="customerId"]').value;
+        await fetch('/api/Customer/' + id, { method: 'DELETE' });
+        const modalEl = this.closest('.modal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+        if (window.loadCustomers) loadCustomers();
+    });
+</script>

--- a/RentACar.Web/wwwroot/css/customers.css
+++ b/RentACar.Web/wwwroot/css/customers.css
@@ -1,0 +1,68 @@
+:root {
+    --primary-dark: #0a0c0e;
+    --secondary-dark: #161819;
+    --accent-gold: #d4af37;
+    --accent-gold-hover: #e6c347;
+    --text-primary: #ffffff;
+    --text-secondary: #9ea3a9;
+}
+
+body {
+    background: var(--primary-dark);
+    color: var(--text-primary);
+    font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
+    padding: 20px;
+}
+
+.customer-container {
+    background: var(--secondary-dark);
+    padding: 30px;
+    border-radius: 20px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.05);
+}
+
+.table-dark th, .table-dark td {
+    color: var(--text-primary);
+}
+
+.table-dark th {
+    color: var(--accent-gold);
+}
+
+.btn-primary {
+    background-color: var(--accent-gold);
+    border-color: var(--accent-gold);
+    color: var(--primary-dark);
+}
+
+.btn-primary:hover, .btn-primary:focus {
+    background-color: var(--accent-gold-hover);
+    border-color: var(--accent-gold-hover);
+    color: var(--primary-dark);
+}
+
+input.form-control, select.form-select {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.1);
+    color: var(--text-primary);
+}
+
+input.form-control:focus, select.form-select:focus {
+    background: rgba(255,255,255,0.05);
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 0 3px rgba(212,175,55,0.1);
+    color: var(--text-primary);
+}
+
+.dark-modal {
+    background: var(--secondary-dark);
+    color: var(--text-primary);
+}
+
+.dark-modal .modal-header, .dark-modal .modal-footer {
+    border-color: rgba(255,255,255,0.1);
+}
+
+.dark-modal .btn-close {
+    filter: invert(1);
+}


### PR DESCRIPTION
## Summary
- implement customer management with CRUD and password reset
- add controller and views with Bootstrap styling
- extend Customer DTO and repository to include phone number and user info
- add managers functionality for updating customers and resetting passwords
- provide new stylesheet for customers

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1b3fb3488321a6dd9b9b14c4e6c6