### PR TITLE
Implement Blacklist admin pages

### DIFF
--- a/RentACar.Application/DTOs/BlackListDto.cs
+++ b/RentACar.Application/DTOs/BlackListDto.cs
@@ -17,8 +17,7 @@ namespace RentACar.Application.DTOs
         public DateOnly DateBlocked { get; set; }
 
         [Required]
-        [StringLength(450)]
-        public string EmployeeDoneBlacklistId { get; set; } = null!;
+        public int EmployeeDoneBlacklistId { get; set; }
     }
 
     public class AddToBlacklistRequestDto

--- a/RentACar.Application/DTOs/BlacklistDisplayDto.cs
+++ b/RentACar.Application/DTOs/BlacklistDisplayDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace RentACar.Application.DTOs
+{
+    public class BlacklistDisplayDto
+    {
+        public int BlacklistId { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string? Reason { get; set; }
+        public DateOnly DateBlocked { get; set; }
+        public int EmployeeDoneBlacklistId { get; set; }
+        public string EmployeeName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Type of the user being blacklisted (Customer or Employee)
+        /// </summary>
+        public string UserType { get; set; } = string.Empty;
+    }
+}

--- a/RentACar.Web/Controllers/BlacklistController.cs
+++ b/RentACar.Web/Controllers/BlacklistController.cs
@@ -1,0 +1,122 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using RentACar.Application.DTOs;
+using RentACar.Application.Managers;
+using RentACar.Core.Repositories;
+using System.Security.Claims;
+
+namespace RentACar.Web.Controllers
+{
+    [Authorize(Roles = "Admin,Employee")]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class BlacklistController : Controller
+    {
+        private readonly BlacklistManager _blacklistManager;
+        private readonly IEmployeeRepository _employeeRepository;
+        private readonly UserManager<IdentityUser> _userManager;
+
+        public BlacklistController(BlacklistManager blacklistManager, IEmployeeRepository employeeRepository, UserManager<IdentityUser> userManager)
+        {
+            _blacklistManager = blacklistManager;
+            _employeeRepository = employeeRepository;
+            _userManager = userManager;
+        }
+
+        [HttpGet("~/Blacklist")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult Index()
+        {
+            return View("~/Views/ControlPanel/Blacklist/Index.cshtml");
+        }
+
+        [HttpGet("~/Blacklist/Add")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult AddForm()
+        {
+            return PartialView("~/Views/ControlPanel/Blacklist/_AddBlacklistPartial.cshtml", new AddToBlacklistRequestDto());
+        }
+
+        [HttpGet("~/Blacklist/Edit/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> EditForm(int id)
+        {
+            var bl = await _blacklistManager.GetByIdAsync(id);
+            if (bl == null) return NotFound();
+            return PartialView("~/Views/ControlPanel/Blacklist/_EditBlacklistPartial.cshtml", bl);
+        }
+
+        [HttpGet("~/Blacklist/Delete/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> DeleteForm(int id)
+        {
+            var bl = await _blacklistManager.GetByIdAsync(id);
+            if (bl == null) return NotFound();
+            return PartialView("~/Views/ControlPanel/Blacklist/_DeleteBlacklistPartial.cshtml", bl);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<BlacklistDisplayDto>>> Get([FromQuery] string? type, [FromQuery] string? search, [FromQuery] int? offset)
+        {
+            var list = await _blacklistManager.GetAllAsync(type, search, offset ?? 0);
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<BlacklistDto>> Get(int id)
+        {
+            var bl = await _blacklistManager.GetByIdAsync(id);
+            if (bl == null) return NotFound();
+            return Ok(bl);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<BlacklistDto>> Create([FromBody] AddToBlacklistRequestDto dto)
+        {
+            var emp = await GetLoggedEmployee();
+            if (emp == null) return Unauthorized();
+            var created = await _blacklistManager.AddToBlacklistAsync(dto, emp);
+            if (created == null) return BadRequest();
+            return CreatedAtAction(nameof(Get), new { id = created.BlacklistId }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, [FromBody] BlacklistDto dto)
+        {
+            if (id != dto.BlacklistId) return BadRequest();
+            await _blacklistManager.UpdateBlacklistAsync(dto);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var emp = await GetLoggedEmployee();
+            if (emp == null) return Unauthorized();
+            var success = await _blacklistManager.RemoveByIdAsync(id, emp);
+            if (!success) return NotFound();
+            return NoContent();
+        }
+
+        private async Task<EmployeeDto?> GetLoggedEmployee()
+        {
+            var userId = _userManager.GetUserId(User);
+            if (userId == null) return null;
+            var empEntity = await _employeeRepository.GetByIdAsync(userId);
+            if (empEntity == null) return null;
+            return new EmployeeDto
+            {
+                EmployeeId = empEntity.EmployeeId,
+                Name = empEntity.Name,
+                Salary = empEntity.Salary,
+                Address = empEntity.Address,
+                IsActive = empEntity.IsActive,
+                Email = empEntity.User.Email,
+                username = empEntity.User.UserName,
+                PhoneNumber = empEntity.User.PhoneNumber,
+                aspNetUserId = empEntity.aspNetUserId
+            };
+        }
+    }
+}

--- a/RentACar.Web/Program.cs
+++ b/RentACar.Web/Program.cs
@@ -45,13 +45,15 @@ builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
 builder.Services.AddScoped<ICreditCardRepository, CreditCardRepository>();
 builder.Services.AddScoped<ICustomerRepository, CustomerRepository>();
 builder.Services.AddScoped<IEmployeeRepository, EmployeeRepository>();
+builder.Services.AddScoped<IBlacklistRepository, BlacklistRepository>();
 builder.Services.AddHttpContextAccessor();
 // 🔥 Register Managers
 builder.Services.AddScoped<CustomerManager>();
 builder.Services.AddScoped<CategoryManager>();
 builder.Services.AddScoped<RoleManager<IdentityRole>>();
 builder.Services.AddScoped<EmployeeManager>();
-builder.Services.AddScoped<CarManager>(); 
+builder.Services.AddScoped<CarManager>();
+builder.Services.AddScoped<BlacklistManager>();
 
 
 

--- a/RentACar.Web/Views/ControlPanel/Blacklist/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Blacklist/Index.cshtml
@@ -1,0 +1,135 @@
+@{
+    ViewData["Title"] = "Blacklist";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/blacklist.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    <div class="blacklist-container container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <a href="../ControlPanel" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width:40px;height:40px" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <h2 class="flex-grow-1 text-center m-0">Manage Blacklist</h2>
+            <div style="width:40px;"></div>
+        </div>
+        <form id="filterForm" class="row g-2 mb-4 align-items-end">
+            <div class="col">
+                <label class="form-label">Search</label>
+                <input type="text" name="search" class="form-control" placeholder="Name or Reason" />
+            </div>
+            <div class="col">
+                <label class="form-label">Type</label>
+                <select name="type" class="form-select">
+                    <option value="">Any</option>
+                    <option value="Customer">Customer</option>
+                    <option value="Employee">Employee</option>
+                </select>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-secondary">Filter</button>
+            </div>
+            <div class="col-auto ms-auto">
+                <button type="button" id="addBlacklist" class="btn btn-primary"><i class="fas fa-plus me-1"></i>Add to Blacklist</button>
+            </div>
+        </form>
+        <div class="mb-3">
+            <input type="text" id="tableSearch" class="form-control" placeholder="Search table..." />
+        </div>
+        <div class="table-responsive">
+            <table id="blacklistTable" class="table table-striped table-dark align-middle">
+                <thead>
+                    <tr>
+                        <th>User</th>
+                        <th>Reason</th>
+                        <th>Date Blocked</th>
+                        <th>Blocked By</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="blacklistRows"></tbody>
+            </table>
+        </div>
+        <div class="text-center mt-3">
+            <button type="button" id="loadMore" class="btn btn-secondary">Load More</button>
+        </div>
+    </div>
+    <div id="blacklistModalPlaceholder"></div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        let currentOffset = 0;
+        const pageSize = 30;
+        async function loadBlacklist(reset = false) {
+            if (reset) currentOffset = 0;
+            const params = new URLSearchParams(new FormData(document.getElementById('filterForm')));
+            params.append('offset', currentOffset.toString());
+            const res = await fetch('/api/Blacklist?' + params.toString());
+            const data = await res.json();
+            const tbody = document.getElementById('blacklistRows');
+            if (reset) tbody.innerHTML = '';
+            data.forEach(b => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${b.username}</td>
+                    <td>${b.reason ?? ''}</td>
+                    <td>${b.dateBlocked}</td>
+                    <td>${b.employeeName}</td>
+                    <td>
+                        <a href="#" class="text-warning me-2 edit-blacklist" data-id="${b.blacklistId}"><i class="fas fa-pencil-alt"></i></a>
+                        <a href="#" class="text-danger unblock-blacklist" data-id="${b.blacklistId}"><i class="fas fa-unlock"></i></a>
+                    </td>`;
+                tbody.appendChild(row);
+            });
+            currentOffset += data.length;
+            document.getElementById('loadMore').style.display = data.length >= pageSize ? '' : 'none';
+        }
+        async function loadModal(url) {
+            const res = await fetch(url);
+            const html = await res.text();
+            const placeholder = document.getElementById('blacklistModalPlaceholder');
+            placeholder.innerHTML = html;
+            placeholder.querySelectorAll('script').forEach(scr => {
+                const s = document.createElement('script');
+                s.textContent = scr.textContent;
+                document.body.appendChild(s);
+                document.body.removeChild(s);
+            });
+            const modalEl = placeholder.querySelector('.modal');
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+            loadBlacklist(true);
+            document.getElementById('filterForm').addEventListener('submit', e => { e.preventDefault(); loadBlacklist(true); });
+            document.getElementById('addBlacklist').addEventListener('click', () => loadModal('/Blacklist/Add'));
+            document.getElementById('loadMore').addEventListener('click', () => loadBlacklist(false));
+            document.getElementById('blacklistRows').addEventListener('click', e => {
+                const edit = e.target.closest('.edit-blacklist');
+                const del = e.target.closest('.unblock-blacklist');
+                if (edit) {
+                    e.preventDefault();
+                    loadModal('/Blacklist/Edit/' + edit.dataset.id);
+                } else if (del) {
+                    e.preventDefault();
+                    loadModal('/Blacklist/Delete/' + del.dataset.id);
+                }
+            });
+            document.getElementById('tableSearch').addEventListener('keyup', function () {
+                const value = this.value.toLowerCase();
+                document.querySelectorAll('#blacklistTable tbody tr').forEach(tr => {
+                    tr.style.display = tr.textContent.toLowerCase().includes(value) ? '' : 'none';
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Blacklist/_AddBlacklistPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Blacklist/_AddBlacklistPartial.cshtml
@@ -1,0 +1,47 @@
+@model RentACar.Application.DTOs.AddToBlacklistRequestDto
+<div class="modal fade" id="blacklistAddModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">Add To Blacklist</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addBlacklistForm">
+                    <div class="mb-3">
+                        <label class="form-label">Identifier (Username or UserId)</label>
+                        <input asp-for="Identifier" class="form-control" />
+                    </div>
+                    <div class="mb-3 form-check">
+                        <input asp-for="UseUsername" class="form-check-input" />
+                        <label class="form-check-label" asp-for="UseUsername">Identifier is Username</label>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Reason</label>
+                        <input asp-for="Reason" class="form-control" />
+                    </div>
+                    <button type="submit" class="btn btn-primary">Add</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById('addBlacklistForm').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const form = e.target;
+        const data = {
+            identifier: form.Identifier.value,
+            reason: form.Reason.value,
+            useUsername: form.UseUsername.checked
+        };
+        await fetch('/api/Blacklist', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        const modalEl = form.closest('.modal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+        if (window.loadBlacklist) loadBlacklist();
+    });
+</script>

--- a/RentACar.Web/Views/ControlPanel/Blacklist/_DeleteBlacklistPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Blacklist/_DeleteBlacklistPartial.cshtml
@@ -1,0 +1,31 @@
+@model RentACar.Application.DTOs.BlacklistDto
+<div class="modal fade" id="blacklistDeleteModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">Unblock User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="deleteBlacklistForm">
+                <div class="modal-body">
+                    <input type="hidden" name="id" value="@Model.BlacklistId" />
+                    <p>Unblock user <strong>@Model.UserId</strong>?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Unblock</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById('deleteBlacklistForm').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const id = this.querySelector('[name="id"]').value;
+        await fetch('/api/Blacklist/' + id, { method: 'DELETE' });
+        const modalEl = this.closest('.modal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+        if (window.loadBlacklist) loadBlacklist();
+    });
+</script>

--- a/RentACar.Web/Views/ControlPanel/Blacklist/_EditBlacklistPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Blacklist/_EditBlacklistPartial.cshtml
@@ -1,0 +1,54 @@
+@model RentACar.Application.DTOs.BlacklistDto
+<div class="modal fade" id="blacklistEditModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content dark-modal">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit Blacklist</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="editBlacklistForm">
+                    <input type="hidden" asp-for="BlacklistId" />
+                    <div class="mb-3">
+                        <label class="form-label">User Id</label>
+                        <input asp-for="UserId" class="form-control" readonly />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Reason</label>
+                        <input asp-for="Reason" class="form-control" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Date Blocked</label>
+                        <input asp-for="DateBlocked" type="date" class="form-control" />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Employee Id</label>
+                        <input asp-for="EmployeeDoneBlacklistId" class="form-control" />
+                    </div>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById('editBlacklistForm').addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const form = e.target;
+        const data = {
+            blacklistId: parseInt(form.BlacklistId.value),
+            userId: form.UserId.value,
+            reason: form.Reason.value,
+            dateBlocked: form.DateBlocked.value,
+            employeeDoneBlacklistId: parseInt(form.EmployeeDoneBlacklistId.value || '0')
+        };
+        await fetch('/api/Blacklist/' + data.blacklistId, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        const modalEl = form.closest('.modal');
+        bootstrap.Modal.getInstance(modalEl).hide();
+        if (window.loadBlacklist) loadBlacklist();
+    });
+</script>

--- a/RentACar.Web/wwwroot/css/blacklist.css
+++ b/RentACar.Web/wwwroot/css/blacklist.css
@@ -1,0 +1,68 @@
+:root {
+    --primary-dark: #0a0c0e;
+    --secondary-dark: #161819;
+    --accent-gold: #d4af37;
+    --accent-gold-hover: #e6c347;
+    --text-primary: #ffffff;
+    --text-secondary: #9ea3a9;
+}
+
+body {
+    background: var(--primary-dark);
+    color: var(--text-primary);
+    font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
+    padding: 20px;
+}
+
+.blacklist-container {
+    background: var(--secondary-dark);
+    padding: 30px;
+    border-radius: 20px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.05);
+}
+
+.table-dark th, .table-dark td {
+    color: var(--text-primary);
+}
+
+.table-dark th {
+    color: var(--accent-gold);
+}
+
+.btn-primary {
+    background-color: var(--accent-gold);
+    border-color: var(--accent-gold);
+    color: var(--primary-dark);
+}
+
+.btn-primary:hover, .btn-primary:focus {
+    background-color: var(--accent-gold-hover);
+    border-color: var(--accent-gold-hover);
+    color: var(--primary-dark);
+}
+
+input.form-control, select.form-select {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.1);
+    color: var(--text-primary);
+}
+
+input.form-control:focus, select.form-select:focus {
+    background: rgba(255,255,255,0.05);
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 0 3px rgba(212,175,55,0.1);
+    color: var(--text-primary);
+}
+
+.dark-modal {
+    background: var(--secondary-dark);
+    color: var(--text-primary);
+}
+
+.dark-modal .modal-header, .dark-modal .modal-footer {
+    border-color: rgba(255,255,255,0.1);
+}
+
+.dark-modal .btn-close {
+    filter: invert(1);
+}


### PR DESCRIPTION
## Summary
- support listing and editing blacklist entries
- provide API/controller endpoints for blacklist operations
- register blacklist services
- add blacklist control panel view and partials
- style blacklist page
- add filtering, client table search, and pagination controls

## Testing
- `dotnet build RentACar.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef04b51f083219b357e712b081ce3