### PR TITLE
Show car image preview

### DIFF
--- a/RentACar.Application/DTOs/CarDto.cs
+++ b/RentACar.Application/DTOs/CarDto.cs
@@ -25,6 +25,11 @@ namespace RentACar.Application.DTOs
 
         public int? CategoryId { get; set; }
 
+        public byte[]? CarImage { get; set; }
+
+        // when true, existing image will be removed during update
+        public bool RemoveImage { get; set; }
+
         // Optional: To display category name
         public string? CategoryName { get; set; }
        

--- a/RentACar.Application/Managers/CarManager.cs
+++ b/RentACar.Application/Managers/CarManager.cs
@@ -113,6 +113,10 @@ namespace RentACar.Application.Managers
             {
                 _logger.LogInformation("Updating car {Id}", carDto.CarId);
                 _mapper.Map(carDto, existingCar);
+                if (carDto.RemoveImage)
+                {
+                    existingCar.CarImage = null;
+                }
                 await _carRepository.UpdateAsync(existingCar);
             }
             else
@@ -135,8 +139,9 @@ namespace RentACar.Application.Managers
             CreateMap<Car, CarDto>()
                 .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : null))
                 .ReverseMap()
-                .ForMember(dest => dest.Category, opt => opt.Ignore()); // prevent circular/auto creation
-        }
+                .ForMember(dest => dest.Category, opt => opt.Ignore())
+                .ForMember(dest => dest.CarImage, opt => opt.Condition(src => src.CarImage != null)); // only map image if provided
+            }
     }
 
 }

--- a/RentACar.Core/Entities/Car.cs
+++ b/RentACar.Core/Entities/Car.cs
@@ -35,6 +35,9 @@ public partial class Car
     [Column("categoryID")]
     public int? CategoryId { get; set; }
 
+    [Column("carImage")]
+    public byte[]? CarImage { get; set; }
+
     [InverseProperty("Car")]
     public virtual ICollection<Booking> Bookings { get; set; } = new List<Booking>();
 

--- a/RentACar.Web/Views/ControlPanel/Car/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Car/Index.cshtml
@@ -55,6 +55,7 @@
             <table id="carTable" class="table table-striped table-dark align-middle">
                 <thead>
                     <tr>
+                        <th>Image</th>
                         <th>Plate #</th>
                         <th>Model</th>
                         <th>Year</th>
@@ -95,7 +96,10 @@
             tbody.innerHTML = '';
             data.forEach(car => {
                 const row = document.createElement('tr');
+                const imgSrc = car.carImage ? `data:image;base64,${car.carImage}` : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+VXeoAAAAASUVORK5CYII=';
+                const imgCell = `<img class="car-thumb" width="80" height="80" src="${imgSrc}" />`;
                 row.innerHTML = `
+                    <td>${imgCell}</td>
                     <td>${car.plateNumber}</td>
                     <td>${car.modelName}</td>
                     <td>${car.modelYear}</td>

--- a/RentACar.Web/Views/ControlPanel/Car/_CarFormPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Car/_CarFormPartial.cshtml
@@ -31,6 +31,13 @@
         <input asp-for="PricePerDay" class="form-control" />
     </div>
     <div class="mb-3">
+        <label class="form-label">Car Image</label>
+        <input type="file" id="CarImage" class="form-control" accept="image/*" />
+        <img id="CarImagePreview" class="img-thumbnail mt-2 preview-thumb" width="80" height="80" style="object-fit:cover;" src="@(Model.CarImage != null ? $"data:image;base64,{Convert.ToBase64String(Model.CarImage)}" : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+VXeoAAAAASUVORK5CYII=")" />
+        <button type="button" id="RemoveImageBtn" class="btn btn-sm btn-danger mt-2">Remove Image</button>
+        <input type="hidden" id="RemoveImage" value="false" />
+    </div>
+    <div class="mb-3">
         <label class="form-label">Category</label>
         <select asp-for="CategoryId" class="form-select" asp-items="ViewBag.Categories">
             <option value="">-- Select --</option>
@@ -47,6 +54,34 @@
     </div>
 </div>
 <script>
+    const imageInput = document.getElementById('CarImage');
+    const previewImg = document.getElementById('CarImagePreview');
+    const removeBtn = document.getElementById('RemoveImageBtn');
+    const removeField = document.getElementById('RemoveImage');
+
+    removeBtn.addEventListener('click', () => {
+        imageInput.value = '';
+        previewImg.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+VXeoAAAAASUVORK5CYII=';
+        previewImg.style.display = 'block';
+        removeField.value = 'true';
+    });
+
+    imageInput.addEventListener('change', () => {
+        const file = imageInput.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = e => {
+                previewImg.src = e.target.result;
+                previewImg.style.display = 'block';
+            };
+            reader.readAsDataURL(file);
+            removeField.value = 'false';
+        } else {
+            previewImg.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+VXeoAAAAASUVORK5CYII=';
+            previewImg.style.display = 'block';
+        }
+    });
+
     document.getElementById('carForm').addEventListener('submit', async function (e) {
         e.preventDefault();
         const form = e.target;
@@ -60,6 +95,11 @@
             categoryId: parseInt(form.CategoryId.value || '0'),
             isAvailable: form.IsAvailable.checked
         };
+        if (removeField.value === 'true') {
+            data.removeImage = true;
+        } else if (imageInput.files.length > 0) {
+            data.carImage = await toBase64(imageInput.files[0]);
+        }
         const url = data.carId ? '/api/Car/' + data.carId : '/api/Car';
         const method = data.carId ? 'PUT' : 'POST';
         await fetch(url, {
@@ -71,4 +111,16 @@
         bootstrap.Modal.getInstance(modalEl).hide();
         if (window.loadCars) loadCars();
     });
+
+    async function toBase64(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const base64 = reader.result.split(',')[1];
+                resolve(base64);
+            };
+            reader.onerror = reject;
+            reader.readAsDataURL(file);
+        });
+    }
 </script>

--- a/RentACar.Web/wwwroot/css/cars.css
+++ b/RentACar.Web/wwwroot/css/cars.css
@@ -78,3 +78,17 @@ input.form-control, select.form-select {
     .dark-modal .btn-close {
         filter: invert(1);
     }
+
+
+/* Thumbnail displayed in the car listing table */
+.car-thumb {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+}
+
+.preview-thumb {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- display car image as thumbnail in car form
- add css styles for image preview size
- set explicit width/height attributes for table thumbnails and preview
- constrain table car thumbnails to 80x80
- add image removal option with default placeholder
- embed default placeholder as base64 string to avoid binary file

## Testing
- `dotnet build RentACar.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509a1eb7c88321a24f4e5ef4fa9ed0