### PR TITLE
Add dashboards per role

### DIFF
--- a/RentACar.Web/Controllers/DashboardController.cs
+++ b/RentACar.Web/Controllers/DashboardController.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+using RentACar.Web.Models;
+
+namespace RentACar.Web.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class DashboardController : Controller
+    {
+        private readonly CarManager _carManager;
+        private readonly CustomerManager _customerManager;
+        private readonly EmployeeManager _employeeManager;
+        private readonly RentACarDbContext _dbContext;
+        private readonly UserManager<IdentityUser> _userManager;
+
+        public DashboardController(
+            CarManager carManager,
+            CustomerManager customerManager,
+            EmployeeManager employeeManager,
+            RentACarDbContext dbContext,
+            UserManager<IdentityUser> userManager)
+        {
+            _carManager = carManager;
+            _customerManager = customerManager;
+            _employeeManager = employeeManager;
+            _dbContext = dbContext;
+            _userManager = userManager;
+        }
+
+        [HttpGet("~/Dashboard")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> Index()
+        {
+            if (User.IsInRole("Admin"))
+                return await Admin();
+            if (User.IsInRole("Employee"))
+                return await Employee();
+            if (User.IsInRole("Customer"))
+                return await Customer();
+            return RedirectToAction("Index", "Home");
+        }
+
+        [HttpGet("~/Dashboard/Admin")]
+        [Authorize(Roles = "Admin")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> Admin()
+        {
+            var totalCars = (await _carManager.BrowseAllCarsAsync()).Count;
+            var availableCars = (await _carManager.SearchCarsByFilterAsync(isAvailable: true)).Count;
+            var totalCustomers = (await _customerManager.GetAllCustomers()).Count;
+            var totalEmployees = (await _employeeManager.GetAllEmployees()).Count;
+            var totalBookings = await _dbContext.Bookings.CountAsync();
+
+            var monthly = await _dbContext.Bookings
+                .GroupBy(b => b.Startdate.Month)
+                .Select(g => new { Month = g.Key, Count = g.Count() })
+                .OrderBy(g => g.Month)
+                .ToListAsync();
+            var monthCounts = Enumerable.Range(1,12).Select(m => monthly.FirstOrDefault(x=>x.Month==m)?.Count ?? 0).ToList();
+
+            var model = new AdminDashboardViewModel
+            {
+                TotalCars = totalCars,
+                AvailableCars = availableCars,
+                TotalCustomers = totalCustomers,
+                TotalEmployees = totalEmployees,
+                TotalBookings = totalBookings,
+                MonthlyBookings = monthCounts
+            };
+            return View("~/Views/Dashboard/Admin.cshtml", model);
+        }
+
+        [HttpGet("~/Dashboard/Employee")]
+        [Authorize(Roles = "Employee")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> Employee()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return RedirectToAction("Index", "Home");
+            var employee = (await _employeeManager.GetAllEmployees()).FirstOrDefault(e => e.aspNetUserId == user.Id);
+            if (employee == null) return RedirectToAction("Index", "Home");
+
+            var bookings = await _dbContext.Bookings.Where(b => b.EmployeebookerId == employee.EmployeeId).ToListAsync();
+            var monthCounts = bookings
+                .GroupBy(b => b.Startdate.Month)
+                .Select(g => new { Month = g.Key, Count = g.Count() })
+                .ToList();
+            var months = Enumerable.Range(1,12).Select(m => monthCounts.FirstOrDefault(x=>x.Month==m)?.Count ?? 0).ToList();
+
+            var model = new EmployeeDashboardViewModel
+            {
+                EmployeeBookings = bookings.Count,
+                TotalCars = (await _carManager.BrowseAllCarsAsync()).Count,
+                AvailableCars = (await _carManager.SearchCarsByFilterAsync(isAvailable: true)).Count,
+                MonthlyEmployeeBookings = months
+            };
+            return View("~/Views/Dashboard/Employee.cshtml", model);
+        }
+
+        [HttpGet("~/Dashboard/Customer")]
+        [Authorize(Roles = "Customer")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> Customer()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return RedirectToAction("Index", "Home");
+            var customer = (await _customerManager.GetAllCustomers()).FirstOrDefault(c => c.aspNetUserId == user.Id);
+            if (customer == null) return RedirectToAction("Index", "Home");
+
+            var bookings = await _dbContext.Bookings.Where(b => b.CustomerId == customer.UserId).ToListAsync();
+            var upcoming = bookings.Count(b => b.Startdate.ToDateTime(TimeOnly.MinValue) > DateTime.UtcNow);
+            var totalSpent = bookings.Sum(b => b.TotalPrice);
+            var monthCounts = bookings
+                .GroupBy(b => b.Startdate.Month)
+                .Select(g => new { Month = g.Key, Count = g.Count() })
+                .ToList();
+            var months = Enumerable.Range(1,12).Select(m => monthCounts.FirstOrDefault(x=>x.Month==m)?.Count ?? 0).ToList();
+
+            var model = new CustomerDashboardViewModel
+            {
+                TotalBookings = bookings.Count,
+                UpcomingBookings = upcoming,
+                TotalSpent = totalSpent,
+                MonthlyBookings = months
+            };
+            return View("~/Views/Dashboard/Customer.cshtml", model);
+        }
+    }
+}
+

--- a/RentACar.Web/Models/DashboardViewModels.cs
+++ b/RentACar.Web/Models/DashboardViewModels.cs
@@ -7,15 +7,21 @@ namespace RentACar.Web.Models
         public int TotalCustomers { get; set; }
         public int TotalEmployees { get; set; }
         public int TotalBookings { get; set; }
+        public decimal IncomeThisMonth { get; set; }
+        public decimal IncomeThisYear { get; set; }
+        public decimal ExpectedRevenue { get; set; }
+        public decimal SalariesToPay { get; set; }
         public List<int> MonthlyBookings { get; set; } = new();
     }
 
     public class EmployeeDashboardViewModel
     {
-        public int EmployeeBookings { get; set; }
+        public int ProcessedBookings { get; set; }
         public int TotalCars { get; set; }
         public int AvailableCars { get; set; }
-        public List<int> MonthlyEmployeeBookings { get; set; } = new();
+        public int UnverifiedCustomers { get; set; }
+        public int WaitingBookings { get; set; }
+        public List<int> MonthlyProcessedBookings { get; set; } = new();
     }
 
     public class CustomerDashboardViewModel
@@ -23,6 +29,8 @@ namespace RentACar.Web.Models
         public int TotalBookings { get; set; }
         public int UpcomingBookings { get; set; }
         public decimal TotalSpent { get; set; }
+        public decimal DiscountSavings { get; set; }
+        public string? BestCategory { get; set; }
         public List<int> MonthlyBookings { get; set; } = new();
     }
 }

--- a/RentACar.Web/Models/DashboardViewModels.cs
+++ b/RentACar.Web/Models/DashboardViewModels.cs
@@ -1,0 +1,28 @@
+namespace RentACar.Web.Models
+{
+    public class AdminDashboardViewModel
+    {
+        public int TotalCars { get; set; }
+        public int AvailableCars { get; set; }
+        public int TotalCustomers { get; set; }
+        public int TotalEmployees { get; set; }
+        public int TotalBookings { get; set; }
+        public List<int> MonthlyBookings { get; set; } = new();
+    }
+
+    public class EmployeeDashboardViewModel
+    {
+        public int EmployeeBookings { get; set; }
+        public int TotalCars { get; set; }
+        public int AvailableCars { get; set; }
+        public List<int> MonthlyEmployeeBookings { get; set; } = new();
+    }
+
+    public class CustomerDashboardViewModel
+    {
+        public int TotalBookings { get; set; }
+        public int UpcomingBookings { get; set; }
+        public decimal TotalSpent { get; set; }
+        public List<int> MonthlyBookings { get; set; } = new();
+    }
+}

--- a/RentACar.Web/Views/Dashboard/Admin.cshtml
+++ b/RentACar.Web/Views/Dashboard/Admin.cshtml
@@ -45,6 +45,32 @@
             </div>
         </div>
     </div>
+    <div class="row g-3 mb-4">
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.IncomeThisMonth.ToString("C")</h3>
+                <span>Income This Month</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.IncomeThisYear.ToString("C")</h3>
+                <span>Income This Year</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.SalariesToPay.ToString("C")</h3>
+                <span>Salaries</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.ExpectedRevenue.ToString("C")</h3>
+                <span>Expected Revenue</span>
+            </div>
+        </div>
+    </div>
 </div>
 @section Scripts{
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/RentACar.Web/Views/Dashboard/Admin.cshtml
+++ b/RentACar.Web/Views/Dashboard/Admin.cshtml
@@ -1,0 +1,69 @@
+@model RentACar.Web.Models.AdminDashboardViewModel
+@{
+    ViewData["Title"] = "Admin Dashboard";
+    Layout = "_Layout";
+}
+<link rel="stylesheet" href="~/css/dashboard.css" />
+<div class="container dashboard-container">
+    <h2 class="text-center mb-4">Admin Dashboard</h2>
+    <div class="row g-3 mb-4">
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalCars</h3>
+                <span>Total Cars</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.AvailableCars</h3>
+                <span>Available Cars</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalCustomers</h3>
+                <span>Customers</span>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalEmployees</h3>
+                <span>Employees</span>
+            </div>
+        </div>
+    </div>
+    <div class="row g-3 mb-4">
+        <div class="col-md-6">
+            <div class="stat-box">
+                <h3>@Model.TotalBookings</h3>
+                <span>Total Bookings</span>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="chart-container">
+                <canvas id="bookingChart"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+@section Scripts{
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const monthData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MonthlyBookings));
+        const ctx = document.getElementById('bookingChart');
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+                datasets: [{
+                    label: 'Bookings',
+                    data: monthData,
+                    borderColor: '#d4af37',
+                    backgroundColor: 'rgba(212,175,55,0.3)',
+                    fill: true
+                }]
+            },
+            options: { scales: { y: { beginAtZero: true } } }
+        });
+    </script>
+}

--- a/RentACar.Web/Views/Dashboard/Customer.cshtml
+++ b/RentACar.Web/Views/Dashboard/Customer.cshtml
@@ -7,27 +7,43 @@
 <div class="container dashboard-container">
     <h2 class="text-center mb-4">My Dashboard</h2>
     <div class="row g-3 mb-4">
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
                 <h3>@Model.TotalBookings</h3>
                 <span>Total Bookings</span>
             </div>
         </div>
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
                 <h3>@Model.UpcomingBookings</h3>
                 <span>Upcoming</span>
             </div>
         </div>
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
                 <h3>@Model.TotalSpent.ToString("C")</h3>
                 <span>Total Spent</span>
             </div>
         </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.DiscountSavings.ToString("C")</h3>
+                <span>Saved via Discounts</span>
+            </div>
+        </div>
     </div>
-    <div class="chart-container">
-        <canvas id="custChart"></canvas>
+    <div class="row g-3 mb-4">
+        <div class="col-md-6">
+            <div class="chart-container">
+                <canvas id="custChart"></canvas>
+            </div>
+        </div>
+        <div class="col-md-6 d-flex align-items-center">
+            <div class="stat-box w-100">
+                <h3>@Model.BestCategory</h3>
+                <span>Favorite Category</span>
+            </div>
+        </div>
     </div>
 </div>
 @section Scripts{

--- a/RentACar.Web/Views/Dashboard/Customer.cshtml
+++ b/RentACar.Web/Views/Dashboard/Customer.cshtml
@@ -1,0 +1,52 @@
+@model RentACar.Web.Models.CustomerDashboardViewModel
+@{
+    ViewData["Title"] = "Customer Dashboard";
+    Layout = "_Layout";
+}
+<link rel="stylesheet" href="~/css/dashboard.css" />
+<div class="container dashboard-container">
+    <h2 class="text-center mb-4">My Dashboard</h2>
+    <div class="row g-3 mb-4">
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalBookings</h3>
+                <span>Total Bookings</span>
+            </div>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.UpcomingBookings</h3>
+                <span>Upcoming</span>
+            </div>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalSpent.ToString("C")</h3>
+                <span>Total Spent</span>
+            </div>
+        </div>
+    </div>
+    <div class="chart-container">
+        <canvas id="custChart"></canvas>
+    </div>
+</div>
+@section Scripts{
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MonthlyBookings));
+        new Chart(document.getElementById('custChart'), {
+            type: 'line',
+            data: {
+                labels: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+                datasets: [{
+                    label: 'Bookings',
+                    data: data,
+                    borderColor: '#d4af37',
+                    backgroundColor: 'rgba(212,175,55,0.3)',
+                    fill: true
+                }]
+            },
+            options: { scales: { y: { beginAtZero: true } } }
+        });
+    </script>
+}

--- a/RentACar.Web/Views/Dashboard/Employee.cshtml
+++ b/RentACar.Web/Views/Dashboard/Employee.cshtml
@@ -1,0 +1,50 @@
+@model RentACar.Web.Models.EmployeeDashboardViewModel
+@{
+    ViewData["Title"] = "Employee Dashboard";
+    Layout = "_Layout";
+}
+<link rel="stylesheet" href="~/css/dashboard.css" />
+<div class="container dashboard-container">
+    <h2 class="text-center mb-4">Employee Dashboard</h2>
+    <div class="row g-3 mb-4">
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.EmployeeBookings</h3>
+                <span>My Bookings</span>
+            </div>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.TotalCars</h3>
+                <span>Total Cars</span>
+            </div>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.AvailableCars</h3>
+                <span>Available Cars</span>
+            </div>
+        </div>
+    </div>
+    <div class="chart-container">
+        <canvas id="empChart"></canvas>
+    </div>
+</div>
+@section Scripts{
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MonthlyEmployeeBookings));
+        new Chart(document.getElementById('empChart'), {
+            type: 'bar',
+            data: {
+                labels: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+                datasets: [{
+                    label: 'Bookings',
+                    data: data,
+                    backgroundColor: '#d4af37'
+                }]
+            },
+            options: { scales: { y: { beginAtZero: true } } }
+        });
+    </script>
+}

--- a/RentACar.Web/Views/Dashboard/Employee.cshtml
+++ b/RentACar.Web/Views/Dashboard/Employee.cshtml
@@ -7,33 +7,49 @@
 <div class="container dashboard-container">
     <h2 class="text-center mb-4">Employee Dashboard</h2>
     <div class="row g-3 mb-4">
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
-                <h3>@Model.EmployeeBookings</h3>
-                <span>My Bookings</span>
+                <h3>@Model.ProcessedBookings</h3>
+                <span>Bookings Processed</span>
             </div>
         </div>
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
                 <h3>@Model.TotalCars</h3>
                 <span>Total Cars</span>
             </div>
         </div>
-        <div class="col-md-4 col-sm-6">
+        <div class="col-md-3 col-sm-6">
             <div class="stat-box">
                 <h3>@Model.AvailableCars</h3>
                 <span>Available Cars</span>
             </div>
         </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.UnverifiedCustomers</h3>
+                <span>Unverified Customers</span>
+            </div>
+        </div>
     </div>
-    <div class="chart-container">
-        <canvas id="empChart"></canvas>
+    <div class="row g-3 mb-4">
+        <div class="col-md-6 col-sm-6">
+            <div class="stat-box">
+                <h3>@Model.WaitingBookings</h3>
+                <span>Pending Bookings</span>
+            </div>
+        </div>
+        <div class="col-md-6 col-sm-6">
+            <div class="chart-container">
+                <canvas id="empChart"></canvas>
+            </div>
+        </div>
     </div>
 </div>
 @section Scripts{
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MonthlyEmployeeBookings));
+        const data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MonthlyProcessedBookings));
         new Chart(document.getElementById('empChart'), {
             type: 'bar',
             data: {

--- a/RentACar.Web/Views/Shared/_Layout.cshtml
+++ b/RentACar.Web/Views/Shared/_Layout.cshtml
@@ -28,6 +28,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-light" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
+                        @if (SignInManager.IsSignedIn(User))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-light" asp-controller="Dashboard" asp-action="Index">Dashboard</a>
+                            </li>
+                        }
                         @if (User.IsInRole("Admin") || User.IsInRole("Employee"))
                         {
                             <li class="nav-item">

--- a/RentACar.Web/wwwroot/css/dashboard.css
+++ b/RentACar.Web/wwwroot/css/dashboard.css
@@ -28,11 +28,17 @@ body {
     padding: 20px;
     text-align: center;
     color: var(--text-primary);
+    height: 100%;
 }
 
 .stat-box h3 {
     color: var(--accent-gold);
     margin-bottom: 0.5rem;
+    font-size: 2rem;
+}
+
+.stat-box span {
+    color: var(--text-secondary);
 }
 
 .chart-container {
@@ -40,4 +46,5 @@ body {
     border: 1px solid rgba(255,255,255,0.1);
     border-radius: 12px;
     padding: 20px;
+    height: 100%;
 }

--- a/RentACar.Web/wwwroot/css/dashboard.css
+++ b/RentACar.Web/wwwroot/css/dashboard.css
@@ -1,0 +1,43 @@
+:root {
+    --primary-dark: #0a0c0e;
+    --secondary-dark: #161819;
+    --accent-gold: #d4af37;
+    --accent-gold-hover: #e6c347;
+    --text-primary: #ffffff;
+    --text-secondary: #9ea3a9;
+}
+
+body {
+    background: var(--primary-dark);
+    color: var(--text-primary);
+    font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
+}
+
+.dashboard-container {
+    background: var(--secondary-dark);
+    padding: 30px;
+    border-radius: 20px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.05);
+    margin-top: 2rem;
+}
+
+.stat-box {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    color: var(--text-primary);
+}
+
+.stat-box h3 {
+    color: var(--accent-gold);
+    margin-bottom: 0.5rem;
+}
+
+.chart-container {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 20px;
+}


### PR DESCRIPTION
## Summary
- implement `DashboardController` that serves admin, employee and customer dashboards
- create dashboard view models for stats
- add dashboard pages with Chart.js graphs
- style dashboards with new CSS
- show a Dashboard link in the navbar when logged in

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851acd530208321968573787afdb92e