### PR TITLE
Add PaymentMethod entity with CRUD operations

### DIFF
--- a/RentACar.Application/DTOs/PaymentMethodDto.cs
+++ b/RentACar.Application/DTOs/PaymentMethodDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Application.DTOs
+{
+    public class PaymentMethodDto
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string PaymentMethodName { get; set; } = null!;
+    }
+}

--- a/RentACar.Application/Managers/PaymentMethodManager.cs
+++ b/RentACar.Application/Managers/PaymentMethodManager.cs
@@ -1,0 +1,126 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using RentACar.Application.DTOs;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+
+namespace RentACar.Application.Managers
+{
+    public class PaymentMethodManager
+    {
+        private readonly IPaymentMethodRepository _paymentMethodRepository;
+        private readonly IMapper _mapper;
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly ILogger<PaymentMethodManager> _logger;
+
+        public PaymentMethodManager(IPaymentMethodRepository paymentMethodRepository,
+                                    IMapper mapper,
+                                    UserManager<IdentityUser> userManager,
+                                    ILogger<PaymentMethodManager> logger)
+        {
+            _paymentMethodRepository = paymentMethodRepository;
+            _mapper = mapper;
+            _userManager = userManager;
+            _logger = logger;
+        }
+
+        public async Task<PaymentMethodDto?> AddPaymentMethodAsync(PaymentMethodDto dto, string userId)
+        {
+            _logger.LogInformation("Adding payment method {Name}", dto.PaymentMethodName);
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null || !await _userManager.IsInRoleAsync(user, "Admin"))
+            {
+                _logger.LogWarning("User {UserId} not authorized to add payment methods", userId);
+                return null;
+            }
+
+            var existing = await _paymentMethodRepository.GetByNameAsync(dto.PaymentMethodName);
+            if (existing != null)
+            {
+                _logger.LogWarning("Payment method name {Name} already exists", dto.PaymentMethodName);
+                return null;
+            }
+
+            var entity = _mapper.Map<PaymentMethod>(dto);
+            await _paymentMethodRepository.AddAsync(entity);
+            return _mapper.Map<PaymentMethodDto>(entity);
+        }
+
+        public async Task<PaymentMethodDto?> GetPaymentMethodByIdAsync(int id)
+        {
+            var entity = await _paymentMethodRepository.GetByIdAsync(id);
+            return _mapper.Map<PaymentMethodDto>(entity);
+        }
+
+        public async Task<PaymentMethodDto?> GetPaymentMethodByNameAsync(string name)
+        {
+            var entity = await _paymentMethodRepository.GetByNameAsync(name);
+            return _mapper.Map<PaymentMethodDto>(entity);
+        }
+
+        public async Task<List<PaymentMethodDto>> GetAllPaymentMethodsAsync()
+        {
+            var list = await _paymentMethodRepository.GetAllAsync();
+            return _mapper.Map<List<PaymentMethodDto>>(list);
+        }
+
+        public async Task<PaymentMethodDto?> UpdatePaymentMethodAsync(PaymentMethodDto dto, string userId)
+        {
+            _logger.LogInformation("Updating payment method {Id}", dto.Id);
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null || !await _userManager.IsInRoleAsync(user, "Admin"))
+            {
+                _logger.LogWarning("User {UserId} not authorized to update payment methods", userId);
+                return null;
+            }
+
+            var existing = await _paymentMethodRepository.GetByIdAsync(dto.Id);
+            if (existing == null)
+            {
+                _logger.LogWarning("Payment method {Id} not found", dto.Id);
+                return null;
+            }
+
+            var methodWithName = await _paymentMethodRepository.GetByNameAsync(dto.PaymentMethodName);
+            if (methodWithName != null && methodWithName.Id != dto.Id)
+            {
+                _logger.LogWarning("Payment method name {Name} already exists", dto.PaymentMethodName);
+                return null;
+            }
+
+            _mapper.Map(dto, existing);
+            await _paymentMethodRepository.UpdateAsync(existing);
+            return _mapper.Map<PaymentMethodDto>(existing);
+        }
+
+        public async Task<bool> DeletePaymentMethodAsync(int id, string userId)
+        {
+            _logger.LogInformation("Deleting payment method {Id}", id);
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null || !await _userManager.IsInRoleAsync(user, "Admin"))
+            {
+                _logger.LogWarning("User {UserId} not authorized to delete payment method", userId);
+                return false;
+            }
+
+            var existing = await _paymentMethodRepository.GetByIdAsync(id);
+            if (existing == null)
+            {
+                _logger.LogWarning("Payment method {Id} not found", id);
+                return false;
+            }
+
+            await _paymentMethodRepository.DeleteAsync(id);
+            return true;
+        }
+    }
+
+    public class PaymentMethodProfile : Profile
+    {
+        public PaymentMethodProfile()
+        {
+            CreateMap<PaymentMethod, PaymentMethodDto>().ReverseMap();
+        }
+    }
+}

--- a/RentACar.Core/Entities/PaymentMethod.cs
+++ b/RentACar.Core/Entities/PaymentMethod.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RentACar.Core.Entities;
+
+public partial class PaymentMethod
+{
+    [Key]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [Column("PaymentMethodName")]
+    [StringLength(50)]
+    public string PaymentMethodName { get; set; } = null!;
+}

--- a/RentACar.Core/Repositories/IPaymentMethodRepository.cs
+++ b/RentACar.Core/Repositories/IPaymentMethodRepository.cs
@@ -1,0 +1,11 @@
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories.Base;
+
+namespace RentACar.Core.Repositories
+{
+    public interface IPaymentMethodRepository : IRepository<PaymentMethod>
+    {
+        Task DeleteAsync(int id);
+        Task<PaymentMethod?> GetByNameAsync(string name);
+    }
+}

--- a/RentACar.Infrastructure/Data/RentACarDbContext.cs
+++ b/RentACar.Infrastructure/Data/RentACarDbContext.cs
@@ -42,6 +42,8 @@ public partial class RentACarDbContext : DbContext
 
     public virtual DbSet<Payment> Payments { get; set; }
 
+    public virtual DbSet<PaymentMethod> PaymentMethods { get; set; }
+
     public virtual DbSet<Promocode> Promocodes { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/RentACar.Infrastructure/Data/Repository/PaymentMethodRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/PaymentMethodRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+using RentACar.Infrastructure.Data.Repository.Base;
+
+namespace RentACar.Infrastructure.Data.Repository
+{
+    public class PaymentMethodRepository : Repository<PaymentMethod>, IPaymentMethodRepository
+    {
+        private readonly RentACarDbContext _dbContext;
+
+        public PaymentMethodRepository(RentACarDbContext dbContext) : base(dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var method = await _dbContext.PaymentMethods.FindAsync(id);
+            if (method != null)
+            {
+                _dbContext.PaymentMethods.Remove(method);
+                await _dbContext.SaveChangesAsync();
+            }
+        }
+
+        public async Task<PaymentMethod?> GetByNameAsync(string name)
+        {
+            return await _dbContext.PaymentMethods.FirstOrDefaultAsync(p => p.PaymentMethodName == name);
+        }
+    }
+}

--- a/RentACar.Web/Controllers/PaymentMethodController.cs
+++ b/RentACar.Web/Controllers/PaymentMethodController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using RentACar.Application.DTOs;
+using RentACar.Application.Managers;
+
+namespace RentACar.Web.Controllers
+{
+    [ApiController]
+    [Authorize(Roles = "Admin,Employee")]
+    [Route("api/[controller]")]
+    public class PaymentMethodController : Controller
+    {
+        private readonly PaymentMethodManager _paymentMethodManager;
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly ILogger<PaymentMethodController> _logger;
+
+        public PaymentMethodController(PaymentMethodManager paymentMethodManager,
+                                       UserManager<IdentityUser> userManager,
+                                       ILogger<PaymentMethodController> logger)
+        {
+            _paymentMethodManager = paymentMethodManager;
+            _userManager = userManager;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<PaymentMethodDto>>> Get()
+        {
+            var methods = await _paymentMethodManager.GetAllPaymentMethodsAsync();
+            return Ok(methods);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<PaymentMethodDto>> Get(int id)
+        {
+            var method = await _paymentMethodManager.GetPaymentMethodByIdAsync(id);
+            if (method == null) return NotFound();
+            return Ok(method);
+        }
+
+        [HttpPost]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult<PaymentMethodDto>> Create([FromBody] PaymentMethodDto dto)
+        {
+            _logger.LogInformation("Creating payment method");
+            var userId = _userManager.GetUserId(User) ?? string.Empty;
+            var created = await _paymentMethodManager.AddPaymentMethodAsync(dto, userId);
+            if (created == null) return BadRequest();
+            return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Update(int id, [FromBody] PaymentMethodDto dto)
+        {
+            if (id != dto.Id) return BadRequest();
+            _logger.LogInformation("Updating payment method {Id}", id);
+            var userId = _userManager.GetUserId(User) ?? string.Empty;
+            var updated = await _paymentMethodManager.UpdatePaymentMethodAsync(dto, userId);
+            if (updated == null) return NotFound();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            _logger.LogInformation("Deleting payment method {Id}", id);
+            var userId = _userManager.GetUserId(User) ?? string.Empty;
+            var success = await _paymentMethodManager.DeletePaymentMethodAsync(id, userId);
+            if (!success) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/RentACar.Web/Program.cs
+++ b/RentACar.Web/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<ICustomerRepository, CustomerRepository>();
 builder.Services.AddScoped<IEmployeeRepository, EmployeeRepository>();
 builder.Services.AddScoped<IBlacklistRepository, BlacklistRepository>();
 builder.Services.AddScoped<IPromocodeRepository, PromocodeRepository>();
+builder.Services.AddScoped<IPaymentMethodRepository, PaymentMethodRepository>();
 builder.Services.AddHttpContextAccessor();
 // 🔥 Register Managers
 builder.Services.AddScoped<CustomerManager>();
@@ -67,6 +68,7 @@ builder.Services.AddScoped<CarManager>();
 builder.Services.AddScoped<BlacklistManager>();
 builder.Services.AddScoped<PromocodeManager>();
 builder.Services.AddScoped<CreditCardManager>();
+builder.Services.AddScoped<PaymentMethodManager>();
 
 
 


### PR DESCRIPTION
## Summary
- introduce `PaymentMethod` entity and DTO
- implement repository, manager and Web API controller
- register new services in Program.cs
- expose `PaymentMethods` DbSet in DbContext

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff839c8c8321b64d8421dcc0be5e