### PR TITLE
Improve Browse Cars design

### DIFF
--- a/RentACar.Web/Views/Browse/Index.cshtml
+++ b/RentACar.Web/Views/Browse/Index.cshtml
@@ -11,34 +11,40 @@
 
 <style>
     body {
-        background-color: #000; /* Black background */
-        color: #f8f9fa; /* Light text for contrast */
+        background: linear-gradient(180deg, #0e0e0e, #1b1b1b);
+        color: var(--text-light, #f8f9fa);
+        font-family: 'Poppins', sans-serif;
     }
+
+    .filter-inputs .form-control,
+    .filter-inputs .form-select {
+        background-color: #2a2a2a;
+        border: none;
+        color: var(--text-light, #f8f9fa);
+    }
+
+        .filter-inputs .form-control:focus,
+        .filter-inputs .form-select:focus {
+            box-shadow: 0 0 0 0.2rem rgba(255, 204, 0, 0.25);
+        }
 
     .car-thumb {
         width: 100%;
-        height: 160px;
+        height: 180px;
         object-fit: cover;
-        border-radius: 8px;
     }
 
     .car-card {
-        box-shadow: 0 0 8px rgba(255, 255, 255, 0.1);
-        border-radius: 8px;
-        padding: 15px;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        background-color: #1c1c1c;
-        color: white;
-        transition: transform 0.2s ease;
-        max-width: 260px; /* 👈 Shrink card width */
-        margin: auto;
+        border: none;
+        border-radius: 12px;
+        background-color: #222;
+        overflow: hidden;
+        transition: transform 0.3s, box-shadow 0.3s;
     }
 
         .car-card:hover {
-            transform: scale(1.03);
-            box-shadow: 0 0 16px rgba(255, 255, 255, 0.2);
+            transform: translateY(-4px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
         }
 
     .card-title {
@@ -46,17 +52,11 @@
         margin-top: 10px;
     }
 
-    .card-text {
-        font-size: 0.9rem;
-        margin-bottom: 6px;
-        flex-grow: 1;
-    }
-
     .btn-yellow {
-        background-color: #ffcc00;
+        background-color: var(--accent-yellow, #ffcc00);
         border: none;
-        color: black;
-        font-weight: bold;
+        color: #000;
+        font-weight: 600;
     }
 
         .btn-yellow:hover {
@@ -67,7 +67,7 @@
 <div class="container py-4">
     <h2 class="mb-4 text-white">Browse Cars</h2>
 
-    <form method="get" class="row g-3 mb-4">
+    <form method="get" class="row g-3 mb-4 filter-inputs">
         <div class="col-md-3">
             <input type="text" name="name" class="form-control" placeholder="Car Name" value="@Model.FilterName" />
         </div>
@@ -95,7 +95,7 @@
         </div>
     </form>
 
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4 g-2">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
         @foreach (var car in Model.Cars)
         {
             string imgSrc;


### PR DESCRIPTION
## Summary
- revamp styling for the Browse Cars page
- use modern card hover effects and dark gradient background
- tweak filter form and responsive grid

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68528a4faa9c83218211c5d7382b09ca