### PR TITLE
Handle customer delete constraint errors

### DIFF
--- a/RentACar.Web/Controllers/CustomerController.cs
+++ b/RentACar.Web/Controllers/CustomerController.cs
@@ -4,9 +4,11 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using RentACar.Application.DTOs;
 using RentACar.Application.Managers;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 
 namespace RentACar.Web.Controllers
 {
@@ -112,8 +114,24 @@ namespace RentACar.Web.Controllers
         public async Task<IActionResult> Delete(int id)
         {
             _logger.LogInformation("Deleting customer {Id}", id);
-            await _customerManager.DeleteCustomer(id);
-            return NoContent();
+
+            try
+            {
+                await _customerManager.DeleteCustomer(id);
+                return NoContent();
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogError(ex, "Database constraint prevented deleting customer {Id}", id);
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    "Unable to delete customer because related records exist. Remove the related data before deleting the customer.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while deleting customer {Id}", id);
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    "An unexpected error occurred while deleting the customer. Please try again later.");
+            }
         }
 
         [HttpPost("{id}/reset-password")]

--- a/RentACar.Web/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Customer/_DeleteCustomerPartial.cshtml
@@ -8,6 +8,7 @@
             </div>
             <form id="deleteCustomerForm">
                 <div class="modal-body">
+                    <div class="alert alert-danger d-none" id="deleteCustomerError" role="alert"></div>
                     <input type="hidden" name="customerId" value="@Model.UserId" />
                     <p>Are you sure you want to delete customer <strong>@Model.Name</strong>?</p>
                 </div>
@@ -23,9 +24,50 @@
     document.getElementById('deleteCustomerForm').addEventListener('submit', async function (e) {
         e.preventDefault();
         const id = this.querySelector('[name="customerId"]').value;
-        await fetch('/api/Customer/' + id, { method: 'DELETE' });
-        const modalEl = this.closest('.modal');
-        bootstrap.Modal.getInstance(modalEl).hide();
-        if (window.loadCustomers) loadCustomers();
+        const errorAlert = this.querySelector('#deleteCustomerError');
+        if (errorAlert) {
+            errorAlert.classList.add('d-none');
+            errorAlert.textContent = '';
+        }
+
+        try {
+            const response = await fetch('/api/Customer/' + id, { method: 'DELETE' });
+
+            if (!response.ok) {
+                let message = 'An error occurred while deleting the customer.';
+                const contentType = response.headers.get('Content-Type') || '';
+
+                try {
+                    if (contentType.includes('application/json')) {
+                        const data = await response.json();
+                        if (data && typeof data === 'object') {
+                            message = data.message || message;
+                        }
+                    } else {
+                        const text = await response.text();
+                        if (text) {
+                            message = text;
+                        }
+                    }
+                } catch {
+                    // ignore parsing errors and use default message
+                }
+
+                if (errorAlert) {
+                    errorAlert.textContent = message;
+                    errorAlert.classList.remove('d-none');
+                }
+                return;
+            }
+
+            const modalEl = this.closest('.modal');
+            bootstrap.Modal.getInstance(modalEl).hide();
+            if (window.loadCustomers) loadCustomers();
+        } catch (err) {
+            if (errorAlert) {
+                errorAlert.textContent = 'Unable to connect to the server. Please try again.';
+                errorAlert.classList.remove('d-none');
+            }
+        }
     });
 </script>


### PR DESCRIPTION
## Summary
- return clear internal server error responses when customer deletion fails due to database constraints
- surface API failure details in the customer delete modal so the user sees why the delete failed

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dec4b5f8b88329813b5d66fb41e83f