### PR TITLE
Add control panel pages for managing payments

### DIFF
--- a/RentACar.Application/DTOs/PaymentDetailsDto.cs
+++ b/RentACar.Application/DTOs/PaymentDetailsDto.cs
@@ -30,6 +30,12 @@ namespace RentACar.Application.DTOs
 
         public decimal? BookingSubtotal { get; set; }
 
+        public decimal? BookingDiscountAmount { get; set; }
+
+        public string? PromocodeName { get; set; }
+
+        public decimal? PromocodeDiscountPercentage { get; set; }
+
         public string? CarModel { get; set; }
 
         public string? CarPlateNumber { get; set; }

--- a/RentACar.Application/DTOs/PaymentDetailsDto.cs
+++ b/RentACar.Application/DTOs/PaymentDetailsDto.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace RentACar.Application.DTOs
+{
+    public class PaymentDetailsDto
+    {
+        public int PaymentId { get; set; }
+
+        public int BookingId { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public DateOnly PaymentDate { get; set; }
+
+        public int? CreditcardId { get; set; }
+
+        public string? PaymentMethodName { get; set; }
+
+        public int? PaymentMethodId { get; set; }
+
+        public string? Status { get; set; }
+
+        public string? CustomerName { get; set; }
+
+        public string? CustomerUsername { get; set; }
+
+        public string? BookingStatus { get; set; }
+
+        public decimal? BookingTotal { get; set; }
+
+        public decimal? BookingSubtotal { get; set; }
+
+        public string? CarModel { get; set; }
+
+        public string? CarPlateNumber { get; set; }
+    }
+}

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.AspNetCore.Identity;
@@ -165,10 +166,203 @@ namespace RentACar.Core.Managers
             return _mapper.Map<List<PaymentDto>>(payments);
         }
 
+        public async Task<List<PaymentDetailsDto>> GetAllPaymentsWithDetailsAsync()
+        {
+            var payments = await _paymentRepository.GetAllWithDetailsAsync();
+            var lookup = await BuildPaymentMethodLookupAsync();
+            return payments.Select(p => MapToDetailsDto(p, lookup)).ToList();
+        }
+
+        public async Task<PaymentDetailsDto?> GetPaymentDetailsByIdAsync(int id)
+        {
+            var payment = await _paymentRepository.GetByIdWithDetailsAsync(id);
+            if (payment == null)
+                return null;
+
+            var lookup = await BuildPaymentMethodLookupAsync();
+            return MapToDetailsDto(payment, lookup);
+        }
+
+        public async Task<PaymentDto?> GetPaymentForEditAsync(int id)
+        {
+            var payment = await _paymentRepository.GetByIdAsync(id);
+            if (payment == null)
+                return null;
+
+            var dto = _mapper.Map<PaymentDto>(payment);
+            dto.PaymentMethodId = await ResolvePaymentMethodIdAsync(payment.PaymentMethod);
+            return dto;
+        }
+
+        public async Task<PaymentDto?> AddPaymentAsync(PaymentDto dto)
+        {
+            var booking = await _bookingRepository.GetByIdAsync(dto.BookingId);
+            if (booking == null)
+            {
+                _logger.LogWarning("Attempted to add payment for non-existing booking {BookingId}", dto.BookingId);
+                return null;
+            }
+
+            var existingForBooking = await _paymentRepository.GetPaymentsByBookingIdAsync(dto.BookingId);
+            if (existingForBooking.Any())
+            {
+                _logger.LogWarning("Booking {BookingId} already has an associated payment", dto.BookingId);
+                return null;
+            }
+
+            var paymentMethod = await _paymentMethodRepository.GetByIdAsync(dto.PaymentMethodId);
+            if (paymentMethod == null)
+            {
+                _logger.LogWarning("Attempted to add payment with invalid method {MethodId}", dto.PaymentMethodId);
+                return null;
+            }
+
+            if (paymentMethod.PaymentMethodName.Equals("creditcard", StringComparison.OrdinalIgnoreCase) && !dto.CreditcardId.HasValue)
+            {
+                _logger.LogWarning("Credit card payment requires a card id");
+                return null;
+            }
+
+            if (dto.CreditcardId.HasValue)
+            {
+                var card = await _creditCardRepository.GetByIdAsync(dto.CreditcardId.Value);
+                if (card == null)
+                {
+                    _logger.LogWarning("Invalid credit card {CardId} provided", dto.CreditcardId);
+                    return null;
+                }
+            }
+
+            var payment = new Payment
+            {
+                BookingId = dto.BookingId,
+                Amount = dto.Amount,
+                PaymentDate = dto.PaymentDate,
+                CreditcardId = dto.CreditcardId,
+                PaymentMethod = paymentMethod.PaymentMethodName,
+                Status = dto.Status
+            };
+
+            var created = await _paymentRepository.AddAsync(payment);
+            var result = _mapper.Map<PaymentDto>(created);
+            result.PaymentMethodId = paymentMethod.Id;
+            return result;
+        }
+
+        public async Task<PaymentDto?> UpdatePaymentAsync(PaymentDto dto)
+        {
+            var existing = await _paymentRepository.GetByIdAsync(dto.PaymentId);
+            if (existing == null)
+            {
+                _logger.LogWarning("Attempted to update missing payment {PaymentId}", dto.PaymentId);
+                return null;
+            }
+
+            if (existing.BookingId != dto.BookingId)
+            {
+                var booking = await _bookingRepository.GetByIdAsync(dto.BookingId);
+                if (booking == null)
+                {
+                    _logger.LogWarning("Attempted to move payment {PaymentId} to non-existing booking {BookingId}", dto.PaymentId, dto.BookingId);
+                    return null;
+                }
+
+                var otherPayments = await _paymentRepository.GetPaymentsByBookingIdAsync(dto.BookingId);
+                if (otherPayments.Any(p => p.PaymentId != dto.PaymentId))
+                {
+                    _logger.LogWarning("Booking {BookingId} already has another payment", dto.BookingId);
+                    return null;
+                }
+
+                existing.BookingId = dto.BookingId;
+            }
+
+            var paymentMethod = await _paymentMethodRepository.GetByIdAsync(dto.PaymentMethodId);
+            if (paymentMethod == null)
+            {
+                _logger.LogWarning("Attempted to update payment {PaymentId} with invalid method {MethodId}", dto.PaymentId, dto.PaymentMethodId);
+                return null;
+            }
+
+            if (paymentMethod.PaymentMethodName.Equals("creditcard", StringComparison.OrdinalIgnoreCase) && !dto.CreditcardId.HasValue)
+            {
+                _logger.LogWarning("Credit card payment update requires card id");
+                return null;
+            }
+
+            if (dto.CreditcardId.HasValue)
+            {
+                var card = await _creditCardRepository.GetByIdAsync(dto.CreditcardId.Value);
+                if (card == null)
+                {
+                    _logger.LogWarning("Invalid credit card {CardId} provided for update", dto.CreditcardId);
+                    return null;
+                }
+            }
+
+            existing.Amount = dto.Amount;
+            existing.PaymentDate = dto.PaymentDate;
+            existing.CreditcardId = dto.CreditcardId;
+            existing.PaymentMethod = paymentMethod.PaymentMethodName;
+            existing.Status = dto.Status;
+
+            await _paymentRepository.UpdateAsync(existing);
+            var result = _mapper.Map<PaymentDto>(existing);
+            result.PaymentMethodId = paymentMethod.Id;
+            return result;
+        }
+
         public bool PrintPaymentDocument(int bookingId)
         {
             // To be implemented later
             return true;
+        }
+
+        private PaymentDetailsDto MapToDetailsDto(Payment payment, IReadOnlyDictionary<string, int>? methodLookup = null)
+        {
+            int? methodId = null;
+            if (!string.IsNullOrWhiteSpace(payment.PaymentMethod) && methodLookup != null)
+            {
+                if (methodLookup.TryGetValue(payment.PaymentMethod, out var id))
+                {
+                    methodId = id;
+                }
+            }
+
+            return new PaymentDetailsDto
+            {
+                PaymentId = payment.PaymentId,
+                BookingId = payment.BookingId,
+                Amount = payment.Amount,
+                PaymentDate = payment.PaymentDate,
+                CreditcardId = payment.CreditcardId,
+                PaymentMethodName = payment.PaymentMethod,
+                Status = payment.Status,
+                CustomerName = payment.Booking?.Customer?.Name,
+                CustomerUsername = payment.Booking?.Customer?.User?.UserName,
+                BookingStatus = payment.Booking?.BookingStatus,
+                BookingTotal = payment.Booking?.TotalPrice,
+                BookingSubtotal = payment.Booking?.Subtotal,
+                CarModel = payment.Booking?.Car?.ModelName,
+                CarPlateNumber = payment.Booking?.Car?.PlateNumber,
+                PaymentMethodId = methodId
+            };
+        }
+
+        private async Task<int?> ResolvePaymentMethodIdAsync(string? paymentMethodName)
+        {
+            if (string.IsNullOrWhiteSpace(paymentMethodName))
+                return null;
+
+            var methods = await _paymentMethodRepository.GetAllAsync();
+            var match = methods.FirstOrDefault(m => m.PaymentMethodName.Equals(paymentMethodName, StringComparison.OrdinalIgnoreCase));
+            return match?.Id;
+        }
+
+        private async Task<Dictionary<string, int>> BuildPaymentMethodLookupAsync()
+        {
+            var methods = await _paymentMethodRepository.GetAllAsync();
+            return methods.ToDictionary(m => m.PaymentMethodName, m => m.Id, StringComparer.OrdinalIgnoreCase);
         }
 
       

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -190,7 +190,20 @@ namespace RentACar.Core.Managers
                 return null;
 
             var dto = _mapper.Map<PaymentDto>(payment);
-            dto.PaymentMethodId = await ResolvePaymentMethodIdAsync(payment.PaymentMethod);
+            var methodId = await ResolvePaymentMethodIdAsync(payment.PaymentMethod);
+            if (methodId.HasValue)
+            {
+                dto.PaymentMethodId = methodId.Value;
+            }
+            else
+            {
+                var allMethods = await _paymentMethodRepository.GetAllAsync();
+                var fallback = allMethods.FirstOrDefault();
+                if (fallback != null)
+                {
+                    dto.PaymentMethodId = fallback.Id;
+                }
+            }
             return dto;
         }
 
@@ -244,6 +257,10 @@ namespace RentACar.Core.Managers
             };
 
             var created = await _paymentRepository.AddAsync(payment);
+            if (booking != null)
+            {
+                await UpdateBookingStatusForPaymentAsync(booking, dto.Status);
+            }
             var result = _mapper.Map<PaymentDto>(created);
             result.PaymentMethodId = paymentMethod.Id;
             return result;
@@ -257,6 +274,8 @@ namespace RentACar.Core.Managers
                 _logger.LogWarning("Attempted to update missing payment {PaymentId}", dto.PaymentId);
                 return null;
             }
+
+            Booking? bookingForStatus = null;
 
             if (existing.BookingId != dto.BookingId)
             {
@@ -275,6 +294,7 @@ namespace RentACar.Core.Managers
                 }
 
                 existing.BookingId = dto.BookingId;
+                bookingForStatus = booking;
             }
 
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(dto.PaymentMethodId);
@@ -307,6 +327,14 @@ namespace RentACar.Core.Managers
             existing.Status = dto.Status;
 
             await _paymentRepository.UpdateAsync(existing);
+            if (bookingForStatus == null)
+            {
+                bookingForStatus = await _bookingRepository.GetByIdAsync(existing.BookingId);
+            }
+            if (bookingForStatus != null)
+            {
+                await UpdateBookingStatusForPaymentAsync(bookingForStatus, dto.Status);
+            }
             var result = _mapper.Map<PaymentDto>(existing);
             result.PaymentMethodId = paymentMethod.Id;
             return result;
@@ -321,12 +349,26 @@ namespace RentACar.Core.Managers
         private PaymentDetailsDto MapToDetailsDto(Payment payment, IReadOnlyDictionary<string, int>? methodLookup = null)
         {
             int? methodId = null;
-            if (!string.IsNullOrWhiteSpace(payment.PaymentMethod) && methodLookup != null)
+            if (!string.IsNullOrWhiteSpace(payment.PaymentMethod) && methodLookup != null &&
+                methodLookup.TryGetValue(payment.PaymentMethod, out var resolvedId))
             {
-                if (methodLookup.TryGetValue(payment.PaymentMethod, out var id))
-                {
-                    methodId = id;
-                }
+                methodId = resolvedId;
+            }
+
+            var subtotal = payment.Booking?.Subtotal;
+            var promocode = payment.Booking?.Promocode;
+            var discountPercentage = promocode?.DiscountPercentage;
+
+            decimal? discountAmount = null;
+            if (discountPercentage.HasValue && subtotal.HasValue)
+            {
+                discountAmount = Math.Round(subtotal.Value * discountPercentage.Value / 100m, 2, MidpointRounding.AwayFromZero);
+            }
+
+            var total = payment.Booking?.TotalPrice;
+            if (!total.HasValue && subtotal.HasValue)
+            {
+                total = discountAmount.HasValue ? subtotal.Value - discountAmount.Value : subtotal.Value;
             }
 
             return new PaymentDetailsDto
@@ -341,8 +383,11 @@ namespace RentACar.Core.Managers
                 CustomerName = payment.Booking?.Customer?.Name,
                 CustomerUsername = payment.Booking?.Customer?.User?.UserName,
                 BookingStatus = payment.Booking?.BookingStatus,
-                BookingTotal = payment.Booking?.TotalPrice,
-                BookingSubtotal = payment.Booking?.Subtotal,
+                BookingTotal = total,
+                BookingSubtotal = subtotal,
+                BookingDiscountAmount = discountAmount,
+                PromocodeName = promocode?.Name,
+                PromocodeDiscountPercentage = discountPercentage,
                 CarModel = payment.Booking?.Car?.ModelName,
                 CarPlateNumber = payment.Booking?.Car?.PlateNumber,
                 PaymentMethodId = methodId
@@ -363,6 +408,27 @@ namespace RentACar.Core.Managers
         {
             var methods = await _paymentMethodRepository.GetAllAsync();
             return methods.ToDictionary(m => m.PaymentMethodName, m => m.Id, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private async Task UpdateBookingStatusForPaymentAsync(Booking booking, string? paymentStatus)
+        {
+            if (string.IsNullOrWhiteSpace(paymentStatus))
+            {
+                return;
+            }
+
+            if (paymentStatus.Equals("rejected", StringComparison.OrdinalIgnoreCase) ||
+                paymentStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase))
+            {
+                var targetStatus = paymentStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase)
+                    ? "cancelled"
+                    : "rejected";
+                if (!string.Equals(booking.BookingStatus, targetStatus, StringComparison.OrdinalIgnoreCase))
+                {
+                    booking.BookingStatus = targetStatus;
+                    await _bookingRepository.UpdateAsync(booking);
+                }
+            }
         }
 
       

--- a/RentACar.Core/Repositories/IPaymentRepository.cs
+++ b/RentACar.Core/Repositories/IPaymentRepository.cs
@@ -12,6 +12,10 @@ namespace RentACar.Core.Repositories
     {
         Task<List<Payment>> GetPaymentsByBookingIdAsync(int bookingId);
 
+        Task<List<Payment>> GetAllWithDetailsAsync();
+
+        Task<Payment?> GetByIdWithDetailsAsync(int id);
+
     }
 
 }

--- a/RentACar.Infrastructure/Data/Repository/PaymentRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/PaymentRepository.cs
@@ -29,6 +29,8 @@ namespace RentACar.Infrastructure.Data.Repository
                                            .ThenInclude(c => c.User)
                                    .Include(p => p.Booking)
                                        .ThenInclude(b => b.Car)
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Promocode)
                                    .AsNoTracking()
                                    .ToListAsync();
         }
@@ -41,6 +43,8 @@ namespace RentACar.Infrastructure.Data.Repository
                                            .ThenInclude(c => c.User)
                                    .Include(p => p.Booking)
                                        .ThenInclude(b => b.Car)
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Promocode)
                                    .AsNoTracking()
                                    .FirstOrDefaultAsync(p => p.PaymentId == id);
         }

--- a/RentACar.Infrastructure/Data/Repository/PaymentRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/PaymentRepository.cs
@@ -20,5 +20,29 @@ namespace RentACar.Infrastructure.Data.Repository
                                    .Where(p => p.BookingId == bookingId)
                                    .ToListAsync();
         }
+
+        public async Task<List<Payment>> GetAllWithDetailsAsync()
+        {
+            return await _dbContext.Payments
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Customer)
+                                           .ThenInclude(c => c.User)
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Car)
+                                   .AsNoTracking()
+                                   .ToListAsync();
+        }
+
+        public async Task<Payment?> GetByIdWithDetailsAsync(int id)
+        {
+            return await _dbContext.Payments
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Customer)
+                                           .ThenInclude(c => c.User)
+                                   .Include(p => p.Booking)
+                                       .ThenInclude(b => b.Car)
+                                   .AsNoTracking()
+                                   .FirstOrDefaultAsync(p => p.PaymentId == id);
+        }
     }
 }

--- a/RentACar.Web/Controllers/PaymentController.cs
+++ b/RentACar.Web/Controllers/PaymentController.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using RentACar.Application.DTOs;
+using RentACar.Application.Managers;
+
+namespace RentACar.Web.Controllers
+{
+    [Authorize(Roles = "Admin,Employee")]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PaymentController : Controller
+    {
+        private readonly PaymentManager _paymentManager;
+        private readonly ILogger<PaymentController> _logger;
+
+        public PaymentController(PaymentManager paymentManager, ILogger<PaymentController> logger)
+        {
+            _paymentManager = paymentManager;
+            _logger = logger;
+        }
+
+        [HttpGet("~/Payment")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult Index()
+        {
+            return View("~/Views/ControlPanel/Payment/Index.cshtml");
+        }
+
+        [HttpGet("~/Payment/Add")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public IActionResult AddView()
+        {
+            return View("~/Views/ControlPanel/Payment/Add.cshtml", new PaymentDto
+            {
+                PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow)
+            });
+        }
+
+        [HttpGet("~/Payment/Edit/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> EditView(int id)
+        {
+            var payment = await _paymentManager.GetPaymentForEditAsync(id);
+            if (payment == null)
+            {
+                return NotFound();
+            }
+
+            return View("~/Views/ControlPanel/Payment/Edit.cshtml", payment);
+        }
+
+        [HttpGet("~/Payment/Details/{id}")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public async Task<IActionResult> DetailsView(int id)
+        {
+            var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+            if (payment == null)
+            {
+                return NotFound();
+            }
+
+            return View("~/Views/ControlPanel/Payment/Details.cshtml", payment);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<PaymentDetailsDto>>> Get()
+        {
+            var payments = await _paymentManager.GetAllPaymentsWithDetailsAsync();
+            return Ok(payments);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<PaymentDetailsDto>> Get(int id)
+        {
+            var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+            if (payment == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(payment);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<PaymentDto>> Create([FromBody] PaymentDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var created = await _paymentManager.AddPaymentAsync(dto);
+            if (created == null)
+            {
+                _logger.LogWarning("Failed to create payment for booking {BookingId}", dto.BookingId);
+                return BadRequest("Unable to create payment. Please verify booking and payment method.");
+            }
+
+            return CreatedAtAction(nameof(Get), new { id = created.PaymentId }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, [FromBody] PaymentDto dto)
+        {
+            if (id != dto.PaymentId)
+            {
+                return BadRequest("ID mismatch");
+            }
+
+            var updated = await _paymentManager.UpdatePaymentAsync(dto);
+            if (updated == null)
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+    }
+}

--- a/RentACar.Web/Views/ControlPanel/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Index.cshtml
@@ -51,6 +51,11 @@
                 <div>Payment Methods</div>
             </a>
 
+            <a asp-controller="Payment" asp-action="Index" class="panel-action">
+                <i class="fas fa-file-invoice-dollar"></i>
+                <div>Payments</div>
+            </a>
+
             <a asp-controller="Booking" asp-action="Index" class="panel-action">
                 <i class="fas fa-calendar-check"></i>
                 <div>Bookings</div>

--- a/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
@@ -51,7 +51,12 @@
                 </div>
                 <div class="input mb-4">
                     <label class="form-label text-white">Status</label>
-                    <input name="Status" class="form-control" placeholder="Status" />
+                    <select name="Status" class="form-select">
+                        <option value="" selected>Select status</option>
+                        <option value="pending">Pending</option>
+                        <option value="done">Done</option>
+                        <option value="rejected">Rejected</option>
+                    </select>
                 </div>
                 <button type="submit" class="login-btn w-100">Save</button>
             </form>

--- a/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
@@ -1,0 +1,141 @@
+@model RentACar.Application.DTOs.PaymentDto
+@{
+    ViewData["Title"] = "Add Payment";
+    Layout = null;
+    var paymentDateValue = Model.PaymentDate.ToDateTime(TimeOnly.MinValue).ToString("yyyy-MM-dd");
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/login-style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    @await Html.PartialAsync("_PopupNotifications")
+    <div class="container1">
+        <div class="login-container">
+            <a href="/Payment" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <div class="logo-text mt-3">
+                <i class="fas fa-money-bill-wave fa-lg"></i>
+                <div>RentACar</div>
+            </div>
+            <h2 class="mt-4">Add Payment</h2>
+            <form id="addPaymentForm" class="mt-3">
+                <div class="input mb-3">
+                    <label class="form-label text-white">Booking</label>
+                    <select name="BookingId" class="form-select" required></select>
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Amount</label>
+                    <input name="Amount" type="number" step="0.01" min="0" class="form-control" placeholder="Amount" required />
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Payment Date</label>
+                    <input name="PaymentDate" type="date" class="form-control" value="@paymentDateValue" required />
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Payment Method</label>
+                    <select name="PaymentMethodId" class="form-select" required></select>
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Credit Card ID (optional)</label>
+                    <input name="CreditcardId" type="number" min="0" class="form-control" placeholder="Credit Card ID" />
+                </div>
+                <div class="input mb-4">
+                    <label class="form-label text-white">Status</label>
+                    <input name="Status" class="form-control" placeholder="Status" />
+                </div>
+                <button type="submit" class="login-btn w-100">Save</button>
+            </form>
+        </div>
+    </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script>
+        async function loadSelectOptions() {
+            const bookingSelect = document.querySelector('select[name="BookingId"]');
+            const methodSelect = document.querySelector('select[name="PaymentMethodId"]');
+            bookingSelect.innerHTML = '<option value="" disabled selected>Loading...</option>';
+            methodSelect.innerHTML = '<option value="" disabled selected>Loading...</option>';
+            try {
+                const [bookingRes, methodRes] = await Promise.all([
+                    fetch('/api/Booking'),
+                    fetch('/api/PaymentMethod')
+                ]);
+                if (!bookingRes.ok) {
+                    throw new Error('Failed to load bookings');
+                }
+                if (!methodRes.ok) {
+                    throw new Error('Failed to load payment methods');
+                }
+                const bookings = await bookingRes.json();
+                const methods = await methodRes.json();
+                bookingSelect.innerHTML = '<option value="" disabled selected>Select booking</option>';
+                bookings.forEach(b => {
+                    const option = document.createElement('option');
+                    const labelParts = [`#${b.bookingId}`];
+                    if (b.customerName) labelParts.push(b.customerName);
+                    if (b.carModel) labelParts.push(`- ${b.carModel}`);
+                    option.value = b.bookingId;
+                    option.textContent = labelParts.join(' ');
+                    bookingSelect.appendChild(option);
+                });
+                methodSelect.innerHTML = '<option value="" disabled selected>Select method</option>';
+                methods.forEach(m => {
+                    const option = document.createElement('option');
+                    option.value = m.id;
+                    option.textContent = m.paymentMethodName;
+                    methodSelect.appendChild(option);
+                });
+            } catch (error) {
+                console.error(error);
+                if (window.showPopup) {
+                    window.showPopup('Failed to load form data.', 'error');
+                }
+            }
+        }
+
+        document.getElementById('addPaymentForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const form = e.target;
+            const payload = {
+                bookingId: Number(form.BookingId.value),
+                amount: Number(form.Amount.value),
+                paymentDate: form.PaymentDate.value,
+                paymentMethodId: Number(form.PaymentMethodId.value),
+                creditcardId: form.CreditcardId.value ? Number(form.CreditcardId.value) : null,
+                status: form.Status.value || null
+            };
+            try {
+                const res = await fetch('/api/Payment', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (!res.ok) {
+                    throw new Error(await res.text());
+                }
+                if (window.showPopup) {
+                    window.showPopup('Payment added successfully.', 'success');
+                }
+                setTimeout(() => { window.location.href = '/Payment'; }, 900);
+            } catch (error) {
+                console.error(error);
+                if (window.showPopup) {
+                    window.showPopup('Failed to add payment.', 'error');
+                }
+            }
+        });
+
+        document.addEventListener('DOMContentLoaded', loadSelectOptions);
+    </script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Payment/Details.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Details.cshtml
@@ -2,6 +2,11 @@
 @{
     ViewData["Title"] = "Payment Details";
     Layout = null;
+    decimal? discountAmount = Model.BookingDiscountAmount;
+    if (!discountAmount.HasValue && Model.BookingSubtotal.HasValue && Model.BookingTotal.HasValue)
+    {
+        discountAmount = Model.BookingSubtotal.Value - Model.BookingTotal.Value;
+    }
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -37,6 +42,9 @@
                 <h5 class="text-warning">Booking Summary</h5>
                 <p class="mb-1"><strong>Status:</strong> @Model.BookingStatus</p>
                 <p class="mb-1"><strong>Subtotal:</strong> @(Model.BookingSubtotal?.ToString("F2") ?? "-")</p>
+                <p class="mb-1"><strong>Promo Code:</strong> @(string.IsNullOrWhiteSpace(Model.PromocodeName) ? "-" : Model.PromocodeName)</p>
+                <p class="mb-1"><strong>Discount (%):</strong> @(Model.PromocodeDiscountPercentage.HasValue ? Model.PromocodeDiscountPercentage.Value.ToString("F2") + "%" : "-")</p>
+                <p class="mb-1"><strong>Discount Amount:</strong> @(discountAmount.HasValue ? discountAmount.Value.ToString("F2") : "-")</p>
                 <p class="mb-1"><strong>Total:</strong> @(Model.BookingTotal?.ToString("F2") ?? "-")</p>
                 <p class="mb-1"><strong>Car:</strong> @Model.CarModel @if (!string.IsNullOrEmpty(Model.CarPlateNumber)){<text>(@Model.CarPlateNumber)</text>}</p>
             </div>

--- a/RentACar.Web/Views/ControlPanel/Payment/Details.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Details.cshtml
@@ -1,0 +1,48 @@
+@model RentACar.Application.DTOs.PaymentDetailsDto
+@{
+    ViewData["Title"] = "Payment Details";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/login-style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    <div class="container1">
+        <div class="login-container text-start">
+            <a href="/Payment" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <div class="logo-text mt-3">
+                <i class="fas fa-file-invoice-dollar fa-lg"></i>
+                <div>RentACar</div>
+            </div>
+            <h2 class="mt-4">Payment #@Model.PaymentId</h2>
+            <div class="mt-3 bg-dark text-white p-3 rounded">
+                <h5 class="text-warning">Payment Info</h5>
+                <p class="mb-1"><strong>Booking:</strong> #@Model.BookingId</p>
+                <p class="mb-1"><strong>Customer:</strong> @Model.CustomerName @if (!string.IsNullOrEmpty(Model.CustomerUsername)){<text>(@Model.CustomerUsername)</text>}</p>
+                <p class="mb-1"><strong>Amount:</strong> @Model.Amount.ToString("F2")</p>
+                <p class="mb-1"><strong>Date:</strong> @Model.PaymentDate.ToString("yyyy-MM-dd")</p>
+                <p class="mb-1"><strong>Method:</strong> @Model.PaymentMethodName</p>
+                <p class="mb-3"><strong>Status:</strong> @Model.Status</p>
+                <h5 class="text-warning">Booking Summary</h5>
+                <p class="mb-1"><strong>Status:</strong> @Model.BookingStatus</p>
+                <p class="mb-1"><strong>Subtotal:</strong> @(Model.BookingSubtotal?.ToString("F2") ?? "-")</p>
+                <p class="mb-1"><strong>Total:</strong> @(Model.BookingTotal?.ToString("F2") ?? "-")</p>
+                <p class="mb-1"><strong>Car:</strong> @Model.CarModel @if (!string.IsNullOrEmpty(Model.CarPlateNumber)){<text>(@Model.CarPlateNumber)</text>}</p>
+            </div>
+        </div>
+    </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
@@ -1,8 +1,9 @@
 @model RentACar.Application.DTOs.PaymentDto
-@{
+@{ 
     ViewData["Title"] = "Edit Payment";
     Layout = null;
     var paymentDateValue = Model.PaymentDate.ToDateTime(TimeOnly.MinValue).ToString("yyyy-MM-dd");
+    var statusValue = Model.Status?.ToLowerInvariant();
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -52,7 +53,11 @@
                 </div>
                 <div class="input mb-4">
                     <label class="form-label text-white">Status</label>
-                    <input name="Status" class="form-control" value="@Model.Status" />
+                    <select name="Status" class="form-select">
+                        <option value="pending" @(statusValue == "pending" ? "selected" : string.Empty)>Pending</option>
+                        <option value="done" @(statusValue == "done" ? "selected" : string.Empty)>Done</option>
+                        <option value="rejected" @(statusValue == "rejected" ? "selected" : string.Empty)>Rejected</option>
+                    </select>
                 </div>
                 <button type="submit" class="login-btn w-100">Update</button>
             </form>

--- a/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
@@ -1,0 +1,151 @@
+@model RentACar.Application.DTOs.PaymentDto
+@{
+    ViewData["Title"] = "Edit Payment";
+    Layout = null;
+    var paymentDateValue = Model.PaymentDate.ToDateTime(TimeOnly.MinValue).ToString("yyyy-MM-dd");
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/login-style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    @await Html.PartialAsync("_PopupNotifications")
+    <div class="container1">
+        <div class="login-container">
+            <a href="/Payment" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <div class="logo-text mt-3">
+                <i class="fas fa-money-check-alt fa-lg"></i>
+                <div>RentACar</div>
+            </div>
+            <h2 class="mt-4">Edit Payment</h2>
+            <form id="editPaymentForm" class="mt-3">
+                <input type="hidden" name="PaymentId" value="@Model.PaymentId" />
+                <div class="input mb-3">
+                    <label class="form-label text-white">Booking</label>
+                    <select name="BookingId" class="form-select" required></select>
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Amount</label>
+                    <input name="Amount" type="number" step="0.01" min="0" class="form-control" value="@Model.Amount" required />
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Payment Date</label>
+                    <input name="PaymentDate" type="date" class="form-control" value="@paymentDateValue" required />
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Payment Method</label>
+                    <select name="PaymentMethodId" class="form-select" required></select>
+                </div>
+                <div class="input mb-3">
+                    <label class="form-label text-white">Credit Card ID (optional)</label>
+                    <input name="CreditcardId" type="number" min="0" class="form-control" value="@(Model.CreditcardId?.ToString() ?? string.Empty)" />
+                </div>
+                <div class="input mb-4">
+                    <label class="form-label text-white">Status</label>
+                    <input name="Status" class="form-control" value="@Model.Status" />
+                </div>
+                <button type="submit" class="login-btn w-100">Update</button>
+            </form>
+        </div>
+    </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script>
+        async function loadSelectOptions() {
+            const bookingSelect = document.querySelector('select[name="BookingId"]');
+            const methodSelect = document.querySelector('select[name="PaymentMethodId"]');
+            const selectedBooking = '@Model.BookingId';
+            const selectedMethod = '@Model.PaymentMethodId';
+            bookingSelect.innerHTML = '<option value="" disabled selected>Loading...</option>';
+            methodSelect.innerHTML = '<option value="" disabled selected>Loading...</option>';
+            try {
+                const [bookingRes, methodRes] = await Promise.all([
+                    fetch('/api/Booking'),
+                    fetch('/api/PaymentMethod')
+                ]);
+                if (!bookingRes.ok) {
+                    throw new Error('Failed to load bookings');
+                }
+                if (!methodRes.ok) {
+                    throw new Error('Failed to load payment methods');
+                }
+                const bookings = await bookingRes.json();
+                const methods = await methodRes.json();
+                bookingSelect.innerHTML = '';
+                bookings.forEach(b => {
+                    const option = document.createElement('option');
+                    const labelParts = [`#${b.bookingId}`];
+                    if (b.customerName) labelParts.push(b.customerName);
+                    if (b.carModel) labelParts.push(`- ${b.carModel}`);
+                    option.value = b.bookingId;
+                    option.textContent = labelParts.join(' ');
+                    if (String(b.bookingId) === selectedBooking) {
+                        option.selected = true;
+                    }
+                    bookingSelect.appendChild(option);
+                });
+                methodSelect.innerHTML = '';
+                methods.forEach(m => {
+                    const option = document.createElement('option');
+                    option.value = m.id;
+                    option.textContent = m.paymentMethodName;
+                    if (String(m.id) === selectedMethod) {
+                        option.selected = true;
+                    }
+                    methodSelect.appendChild(option);
+                });
+            } catch (error) {
+                console.error(error);
+                if (window.showPopup) {
+                    window.showPopup('Failed to load form data.', 'error');
+                }
+            }
+        }
+
+        document.getElementById('editPaymentForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const form = e.target;
+            const payload = {
+                paymentId: Number(form.PaymentId.value),
+                bookingId: Number(form.BookingId.value),
+                amount: Number(form.Amount.value),
+                paymentDate: form.PaymentDate.value,
+                paymentMethodId: Number(form.PaymentMethodId.value),
+                creditcardId: form.CreditcardId.value ? Number(form.CreditcardId.value) : null,
+                status: form.Status.value || null
+            };
+            try {
+                const res = await fetch(`/api/Payment/${payload.paymentId}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (!res.ok) {
+                    throw new Error(await res.text());
+                }
+                if (window.showPopup) {
+                    window.showPopup('Payment updated successfully.', 'success');
+                }
+                setTimeout(() => { window.location.href = '/Payment'; }, 900);
+            } catch (error) {
+                console.error(error);
+                if (window.showPopup) {
+                    window.showPopup('Failed to update payment.', 'error');
+                }
+            }
+        });
+
+        document.addEventListener('DOMContentLoaded', loadSelectOptions);
+    </script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Payment/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Index.cshtml
@@ -34,6 +34,10 @@
                         <th>ID</th>
                         <th>Booking</th>
                         <th>Customer</th>
+                        <th>Subtotal</th>
+                        <th>Promo Code</th>
+                        <th>Discount %</th>
+                        <th>Total</th>
                         <th>Amount</th>
                         <th>Date</th>
                         <th>Method</th>
@@ -50,13 +54,24 @@
     <script>
         function formatAmount(value) {
             if (value === null || value === undefined) {
-                return '';
+                return '-';
             }
             const number = Number(value);
             if (Number.isNaN(number)) {
                 return value;
             }
             return number.toFixed(2);
+        }
+
+        function formatPercentage(value) {
+            if (value === null || value === undefined) {
+                return '-';
+            }
+            const number = Number(value);
+            if (Number.isNaN(number)) {
+                return value;
+            }
+            return `${number.toFixed(2)}%`;
         }
 
         document.addEventListener('DOMContentLoaded', async () => {
@@ -78,6 +93,10 @@
                         `<td>${payment.paymentId}</td>` +
                         `<td>#${payment.bookingId}</td>` +
                         `<td>${customerDisplay}</td>` +
+                        `<td>${formatAmount(payment.bookingSubtotal)}</td>` +
+                        `<td>${payment.promocodeName ?? '-'}</td>` +
+                        `<td>${formatPercentage(payment.promocodeDiscountPercentage)}</td>` +
+                        `<td>${formatAmount(payment.bookingTotal)}</td>` +
                         `<td>${formatAmount(payment.amount)}</td>` +
                         `<td>${payment.paymentDate ?? ''}</td>` +
                         `<td class='text-capitalize'>${payment.paymentMethodName ?? ''}</td>` +

--- a/RentACar.Web/Views/ControlPanel/Payment/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Index.cshtml
@@ -1,0 +1,100 @@
+@{
+    ViewData["Title"] = "Payments";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/employees.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    @await Html.PartialAsync("_PopupNotifications")
+    <div class="booking-container container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <a href="../ControlPanel" class="btn btn-outline-warning rounded-circle d-inline-flex align-items-center justify-content-center" style="width:40px;height:40px" title="Back">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <h2 class="flex-grow-1 text-center m-0">Manage Payments</h2>
+            <div style="width:40px;"></div>
+        </div>
+        <div class="text-end mb-3">
+            <a href="/Payment/Add" class="btn btn-primary"><i class="fas fa-plus me-1"></i>Add Payment</a>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-dark align-middle">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Booking</th>
+                        <th>Customer</th>
+                        <th>Amount</th>
+                        <th>Date</th>
+                        <th>Method</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="paymentRows"></tbody>
+            </table>
+        </div>
+    </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script>
+        function formatAmount(value) {
+            if (value === null || value === undefined) {
+                return '';
+            }
+            const number = Number(value);
+            if (Number.isNaN(number)) {
+                return value;
+            }
+            return number.toFixed(2);
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            const tbody = document.getElementById('paymentRows');
+            try {
+                const res = await fetch('/api/Payment');
+                if (!res.ok) {
+                    throw new Error(await res.text());
+                }
+                const data = await res.json();
+                tbody.innerHTML = '';
+                data.forEach(payment => {
+                    const customerParts = [];
+                    if (payment.customerName) customerParts.push(payment.customerName);
+                    if (payment.customerUsername) customerParts.push(`(${payment.customerUsername})`);
+                    const customerDisplay = customerParts.join(' ') || '-';
+                    const row = document.createElement('tr');
+                    row.innerHTML =
+                        `<td>${payment.paymentId}</td>` +
+                        `<td>#${payment.bookingId}</td>` +
+                        `<td>${customerDisplay}</td>` +
+                        `<td>${formatAmount(payment.amount)}</td>` +
+                        `<td>${payment.paymentDate ?? ''}</td>` +
+                        `<td class='text-capitalize'>${payment.paymentMethodName ?? ''}</td>` +
+                        `<td class='text-capitalize'>${payment.status ?? ''}</td>` +
+                        `<td>` +
+                        `<a href='/Payment/Details/${payment.paymentId}' class='text-info me-2' title='View details'><i class='fas fa-eye'></i></a>` +
+                        `<a href='/Payment/Edit/${payment.paymentId}' class='text-warning' title='Edit payment'><i class='fas fa-pencil-alt'></i></a>` +
+                        `</td>`;
+                    tbody.appendChild(row);
+                });
+            } catch (error) {
+                console.error(error);
+                if (window.showPopup) {
+                    window.showPopup('Failed to load payments.', 'error');
+                }
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand the payment manager and repository to expose detailed queries and upsert helpers for control panel workflows
- add DTOs, API controller, and Razor pages to list, create, edit, and view payment records with booking, customer, and car context
- link the new payments section from the control panel landing page for admin and employee access

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e98e2f0e38832f8d4f8ebc97573f03