### PR TITLE
Add Stripe payout session support and payment provider fields

### DIFF
--- a/RentACar.Application/DTOs/MakePaymentResultDto.cs
+++ b/RentACar.Application/DTOs/MakePaymentResultDto.cs
@@ -1,0 +1,11 @@
+namespace RentACar.Application.DTOs
+{
+    public class MakePaymentResultDto
+    {
+        public PaymentDto Payment { get; set; } = null!;
+
+        public bool RequiresRedirect { get; set; }
+
+        public string? RedirectUrl { get; set; }
+    }
+}

--- a/RentACar.Application/DTOs/PaymentDetailsDto.cs
+++ b/RentACar.Application/DTOs/PaymentDetailsDto.cs
@@ -20,6 +20,12 @@ namespace RentACar.Application.DTOs
 
         public string? Status { get; set; }
 
+        public string? PaymentProvider { get; set; }
+
+        public string? PaymentProviderSessionId { get; set; }
+
+        public string? PaymentProviderPaymentIntentId { get; set; }
+
         public string? CustomerName { get; set; }
 
         public string? CustomerUsername { get; set; }

--- a/RentACar.Application/DTOs/PaymentDto.cs
+++ b/RentACar.Application/DTOs/PaymentDto.cs
@@ -25,6 +25,15 @@ namespace RentACar.Application.DTOs
 
         [StringLength(50)]
         public string? Status { get; set; }
+
+        [StringLength(30)]
+        public string? PaymentProvider { get; set; }
+
+        [StringLength(100)]
+        public string? PaymentProviderSessionId { get; set; }
+
+        [StringLength(100)]
+        public string? PaymentProviderPaymentIntentId { get; set; }
     }
 
     public class MakePaymentRequestDto

--- a/RentACar.Application/DTOs/StripeCheckoutSessionDto.cs
+++ b/RentACar.Application/DTOs/StripeCheckoutSessionDto.cs
@@ -1,42 +1,45 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace RentACar.Application.DTOs
 {
-    public class StripePayoutSessionRequestDto
+    public class StripeCheckoutSessionRequestDto
     {
-        public int? PaymentId { get; set; }
-
-        public int? BookingId { get; set; }
+        [Required]
+        public int PaymentId { get; set; }
 
         [Required]
-        [Range(0.01, double.MaxValue, ErrorMessage = "Amount must be greater than 0.")]
+        public int BookingId { get; set; }
+
+        [Required]
+        [Range(0.01, double.MaxValue)]
         public decimal Amount { get; set; }
 
         [Required]
         [StringLength(3, MinimumLength = 3)]
         public string Currency { get; set; } = "usd";
 
-        [StringLength(100)]
-        public string? ConnectedAccountId { get; set; }
+        [Required]
+        public string SuccessUrl { get; set; } = null!;
 
-        [StringLength(200)]
+        [Required]
+        public string CancelUrl { get; set; } = null!;
+
         public string? Description { get; set; }
+
+        public Dictionary<string, string>? Metadata { get; set; }
     }
 
-    public class StripePayoutSessionDto
+    public class StripeCheckoutSessionDto
     {
         public string SessionId { get; set; } = string.Empty;
 
+        public string CheckoutUrl { get; set; } = string.Empty;
+
         public string Status { get; set; } = string.Empty;
 
-        public decimal Amount { get; set; }
-
-        public string Currency { get; set; } = string.Empty;
-
-        public string? ConnectedAccountId { get; set; }
-
-        public DateTime CreatedAt { get; set; }
+        public string? PaymentIntentId { get; set; }
 
         public string? RawResponse { get; set; }
     }

--- a/RentACar.Application/DTOs/StripePayoutSessionDto.cs
+++ b/RentACar.Application/DTOs/StripePayoutSessionDto.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Application.DTOs
+{
+    public class StripePayoutSessionRequestDto
+    {
+        public int? PaymentId { get; set; }
+
+        public int? BookingId { get; set; }
+
+        [Required]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Amount must be greater than 0.")]
+        public decimal Amount { get; set; }
+
+        [Required]
+        [StringLength(3, MinimumLength = 3)]
+        public string Currency { get; set; } = "usd";
+
+        [StringLength(100)]
+        public string? ConnectedAccountId { get; set; }
+
+        [StringLength(200)]
+        public string? Description { get; set; }
+    }
+
+    public class StripePayoutSessionDto
+    {
+        public string SessionId { get; set; } = string.Empty;
+
+        public string Status { get; set; } = string.Empty;
+
+        public decimal Amount { get; set; }
+
+        public string Currency { get; set; } = string.Empty;
+
+        public string? ConnectedAccountId { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public string? RawResponse { get; set; }
+    }
+
+    public class StripeWebhookVerificationResultDto
+    {
+        public bool IsValid { get; set; }
+
+        public string? ErrorMessage { get; set; }
+
+        public DateTimeOffset? Timestamp { get; set; }
+    }
+}

--- a/RentACar.Application/Managers/CustomerManager.cs
+++ b/RentACar.Application/Managers/CustomerManager.cs
@@ -133,6 +133,13 @@ namespace RentACar.Application.Managers
             return _mapper.Map<CustomerDTO>(customer);
         }
 
+        public async Task<CustomerDTO?> GetCustomerByAspNetUserId(string aspNetUserId)
+        {
+            _logger.LogInformation("Fetching customer by aspNetUserId {UserId}", aspNetUserId);
+            var customer = await _customerRepository.GetByIdAsync(aspNetUserId);
+            return _mapper.Map<CustomerDTO>(customer);
+        }
+
         public async Task<List<CustomerDTO>> GetAllCustomers()
         {
             var customers = await _customerRepository.GetAllAsync();

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -261,7 +261,10 @@ namespace RentACar.Application.Managers
                 PaymentDate = dto.PaymentDate,
                 CreditcardId = dto.CreditcardId,
                 PaymentMethod = paymentMethod.PaymentMethodName,
-                Status = dto.Status
+                Status = dto.Status,
+                PaymentProvider = dto.PaymentProvider,
+                PaymentProviderSessionId = dto.PaymentProviderSessionId,
+                PaymentProviderPaymentIntentId = dto.PaymentProviderPaymentIntentId
             };
 
             var created = await _paymentRepository.AddAsync(payment);
@@ -333,6 +336,9 @@ namespace RentACar.Application.Managers
             existing.CreditcardId = dto.CreditcardId;
             existing.PaymentMethod = paymentMethod.PaymentMethodName;
             existing.Status = dto.Status;
+            existing.PaymentProvider = dto.PaymentProvider;
+            existing.PaymentProviderSessionId = dto.PaymentProviderSessionId;
+            existing.PaymentProviderPaymentIntentId = dto.PaymentProviderPaymentIntentId;
 
             await _paymentRepository.UpdateAsync(existing);
             if (bookingForStatus == null)
@@ -388,6 +394,9 @@ namespace RentACar.Application.Managers
                 CreditcardId = payment.CreditcardId,
                 PaymentMethodName = payment.PaymentMethod,
                 Status = payment.Status,
+                PaymentProvider = payment.PaymentProvider,
+                PaymentProviderSessionId = payment.PaymentProviderSessionId,
+                PaymentProviderPaymentIntentId = payment.PaymentProviderPaymentIntentId,
                 CustomerName = payment.Booking?.Customer?.Name,
                 CustomerUsername = payment.Booking?.Customer?.User?.UserName,
                 BookingStatus = payment.Booking?.BookingStatus,

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -7,9 +7,11 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using RentACar.Application.DTOs;
+using RentACar.Application.Services;
 using RentACar.Core.Entities;
 using RentACar.Core.Repositories;
 using AspNetUserEntity = RentACar.Core.Entities.AspNetUser;
+using Microsoft.AspNetCore.Http;
 
 namespace RentACar.Application.Managers
 {
@@ -20,6 +22,8 @@ namespace RentACar.Application.Managers
         private readonly ICreditCardRepository _creditCardRepository;
         private readonly IPaymentMethodRepository _paymentMethodRepository;
         private readonly UserManager<IdentityUser> _userManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IStripePaymentService _stripePaymentService;
         private readonly IMapper _mapper;
         private readonly ILogger<PaymentManager> _logger;
         private readonly AuditLogManager _auditLogManager;
@@ -30,6 +34,8 @@ namespace RentACar.Application.Managers
             ICreditCardRepository creditCardRepository,
             IPaymentMethodRepository paymentMethodRepository,
             UserManager<IdentityUser> userManager,
+            IHttpContextAccessor httpContextAccessor,
+            IStripePaymentService stripePaymentService,
             IMapper mapper,
             ILogger<PaymentManager> logger,
             AuditLogManager auditLogManager)
@@ -39,43 +45,58 @@ namespace RentACar.Application.Managers
             _creditCardRepository = creditCardRepository;
             _paymentMethodRepository = paymentMethodRepository;
             _userManager = userManager;
+            _httpContextAccessor = httpContextAccessor;
+            _stripePaymentService = stripePaymentService;
             _mapper = mapper;
             _logger = logger;
             _auditLogManager = auditLogManager;
         }
 
-        public async Task<bool> MakePaymentByCustomerAsync(MakePaymentRequestDto paymentDto, int customerUserId)
+        public async Task<MakePaymentResultDto?> MakePaymentByCustomerAsync(MakePaymentRequestDto paymentDto, int customerUserId)
         {
             _logger.LogInformation("Customer {Id} making payment for booking {Booking}", customerUserId, paymentDto.BookingId);
 
             var booking = await _bookingRepository.GetByIdAsync(paymentDto.BookingId);
             if (booking == null || booking.CustomerId != customerUserId)
-                return false;
+                return null;
 
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(paymentDto.PaymentMethodId);
             if (paymentMethod == null)
-                return false;
+                return null;
+
             if (paymentMethod.PaymentMethodName.Equals("creditcard", StringComparison.OrdinalIgnoreCase))
             {
-                if (!paymentDto.CreditcardId.HasValue)
-                    return false;
-
-                var creditCard = await _creditCardRepository.GetByIdAsync(paymentDto.CreditcardId.Value);
-                if (creditCard == null)
-                    return false;
-
                 var payment = new Payment
                 {
                     BookingId = paymentDto.BookingId,
                     Amount = paymentDto.Amount,
                     PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
-                    CreditcardId = paymentDto.CreditcardId,
                     PaymentMethod = paymentMethod.PaymentMethodName,
-                    Status = "done"
+                    Status = "pending",
+                    PaymentProvider = "Stripe"
                 };
 
-                await _paymentRepository.AddAsync(payment);
-                return true;
+                var created = await _paymentRepository.AddAsync(payment);
+                var session = await CreateStripeCheckoutSessionAsync(created);
+
+                if (string.IsNullOrWhiteSpace(session.CheckoutUrl))
+                {
+                    _logger.LogWarning("Stripe checkout session missing URL for payment {PaymentId}", created.PaymentId);
+                    return null;
+                }
+
+                created.PaymentProviderSessionId = session.SessionId;
+                created.PaymentProviderPaymentIntentId = session.PaymentIntentId;
+                await _paymentRepository.UpdateAsync(created);
+
+                var result = _mapper.Map<PaymentDto>(created);
+                result.PaymentMethodId = paymentMethod.Id;
+                return new MakePaymentResultDto
+                {
+                    Payment = result,
+                    RequiresRedirect = true,
+                    RedirectUrl = session.CheckoutUrl
+                };
             }
             else
             {
@@ -89,29 +110,35 @@ namespace RentACar.Application.Managers
                 };
                 await _paymentRepository.AddAsync(payment);
                 await _auditLogManager.LogAsync("Create", "Payment", payment.PaymentId.ToString(), $"Customer payment of {payment.Amount:C} via {payment.PaymentMethod}");
-                return true;
+                var dto = _mapper.Map<PaymentDto>(payment);
+                dto.PaymentMethodId = paymentMethod.Id;
+                return new MakePaymentResultDto
+                {
+                    Payment = dto,
+                    RequiresRedirect = false
+                };
 
             }
         }
 
-        public async Task<bool> MakePaymentByEmployeeAsync(MakePaymentRequestDto paymentDto, string employeeUserId)
+        public async Task<MakePaymentResultDto?> MakePaymentByEmployeeAsync(MakePaymentRequestDto paymentDto, string employeeUserId)
         {
             _logger.LogInformation("Employee {Id} recording payment for booking {Booking}", employeeUserId, paymentDto.BookingId);
             var user = await _userManager.FindByIdAsync(employeeUserId);
             if (user == null || !await _userManager.IsInRoleAsync(user, "Employee"))
-                return false;
+                return null;
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(paymentDto.PaymentMethodId);
             if (paymentMethod == null)
-                return false;
+                return null;
 
             if (paymentMethod.PaymentMethodName.Equals("creditcard", StringComparison.OrdinalIgnoreCase))
             {
                 if (!paymentDto.CreditcardId.HasValue)
-                    return false;
+                    return null;
 
                 var creditCard = await _creditCardRepository.GetByIdAsync(paymentDto.CreditcardId.Value);
                 if (creditCard == null)
-                    return false;
+                    return null;
 
                 var payment = new Payment
                 {
@@ -127,19 +154,25 @@ namespace RentACar.Application.Managers
 
                 await _auditLogManager.LogAsync("Create", "Payment", payment.PaymentId.ToString(), $"Employee recorded payment of {payment.Amount:C}");
 
-                return true;
+                var dto = _mapper.Map<PaymentDto>(payment);
+                dto.PaymentMethodId = paymentMethod.Id;
+                return new MakePaymentResultDto
+                {
+                    Payment = dto,
+                    RequiresRedirect = false
+                };
             }
             else
             {
                 if (user == null || !await _userManager.IsInRoleAsync(user, "Employee"))
-                    return false;
+                    return null;
 
                 var booking = await _bookingRepository.GetByIdAsync(paymentDto.BookingId);
                 if (booking == null)
-                    return false;
+                    return null;
 
                 if (paymentMethod == null || !paymentMethod.PaymentMethodName.Equals("cash", StringComparison.OrdinalIgnoreCase))
-                    return false;
+                    return null;
 
                 var payment = new Payment
                 {
@@ -152,8 +185,39 @@ namespace RentACar.Application.Managers
 
                 await _paymentRepository.AddAsync(payment);
                 await _auditLogManager.LogAsync("Create", "Payment", payment.PaymentId.ToString(), $"Employee recorded cash payment: {payment.Amount:C}");
-                return true;
+                var dto = _mapper.Map<PaymentDto>(payment);
+                dto.PaymentMethodId = paymentMethod.Id;
+                return new MakePaymentResultDto
+                {
+                    Payment = dto,
+                    RequiresRedirect = false
+                };
             }
+        }
+
+        public async Task<bool> MarkPaymentPaidAsync(int paymentId, string? paymentIntentId, string? sessionId)
+        {
+            var payment = await _paymentRepository.GetByIdAsync(paymentId);
+            if (payment == null)
+            {
+                _logger.LogWarning("Stripe webhook received for missing payment {PaymentId}", paymentId);
+                return false;
+            }
+
+            payment.Status = "done";
+            payment.PaymentProvider = "Stripe";
+            if (!string.IsNullOrWhiteSpace(paymentIntentId))
+            {
+                payment.PaymentProviderPaymentIntentId = paymentIntentId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                payment.PaymentProviderSessionId = sessionId;
+            }
+
+            await _paymentRepository.UpdateAsync(payment);
+            return true;
         }
 
         public async Task<List<PaymentDto>> GetPaymentsByBookingIdAsync(int bookingId)
@@ -446,6 +510,36 @@ namespace RentACar.Application.Managers
                     await _bookingRepository.UpdateAsync(booking);
                 }
             }
+        }
+
+        private async Task<StripeCheckoutSessionDto> CreateStripeCheckoutSessionAsync(Payment payment)
+        {
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext == null)
+            {
+                throw new InvalidOperationException("HTTP context is required to build Stripe return URLs.");
+            }
+
+            var domain = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+            var metadata = new Dictionary<string, string>
+            {
+                ["paymentId"] = payment.PaymentId.ToString(),
+                ["bookingId"] = payment.BookingId.ToString()
+            };
+
+            var request = new StripeCheckoutSessionRequestDto
+            {
+                PaymentId = payment.PaymentId,
+                BookingId = payment.BookingId,
+                Amount = payment.Amount,
+                Currency = "usd",
+                SuccessUrl = $"{domain}/Stripe/Success?session_id={{CHECKOUT_SESSION_ID}}",
+                CancelUrl = $"{domain}/Stripe/Cancel?paymentId={payment.PaymentId}",
+                Description = $"Booking #{payment.BookingId}",
+                Metadata = metadata
+            };
+
+            return await _stripePaymentService.CreateCheckoutSessionAsync(request);
         }
 
       

--- a/RentACar.Application/Services/IStripePaymentService.cs
+++ b/RentACar.Application/Services/IStripePaymentService.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using RentACar.Application.DTOs;
+
+namespace RentACar.Application.Services
+{
+    public interface IStripePaymentService
+    {
+        Task<StripePayoutSessionDto> CreatePayoutSessionAsync(
+            StripePayoutSessionRequestDto request,
+            CancellationToken cancellationToken = default);
+
+        StripeWebhookVerificationResultDto VerifyWebhookSignature(
+            string payload,
+            string signatureHeader,
+            int toleranceSeconds = 300);
+    }
+}

--- a/RentACar.Application/Services/IStripePaymentService.cs
+++ b/RentACar.Application/Services/IStripePaymentService.cs
@@ -6,8 +6,8 @@ namespace RentACar.Application.Services
 {
     public interface IStripePaymentService
     {
-        Task<StripePayoutSessionDto> CreatePayoutSessionAsync(
-            StripePayoutSessionRequestDto request,
+        Task<StripeCheckoutSessionDto> CreateCheckoutSessionAsync(
+            StripeCheckoutSessionRequestDto request,
             CancellationToken cancellationToken = default);
 
         StripeWebhookVerificationResultDto VerifyWebhookSignature(

--- a/RentACar.Application/Services/StripePaymentService.cs
+++ b/RentACar.Application/Services/StripePaymentService.cs
@@ -30,42 +30,37 @@ namespace RentACar.Application.Services
             _webhookSecret = Environment.GetEnvironmentVariable(StripeWebhookSecretEnv);
         }
 
-        public async Task<StripePayoutSessionDto> CreatePayoutSessionAsync(
-            StripePayoutSessionRequestDto request,
+        public async Task<StripeCheckoutSessionDto> CreateCheckoutSessionAsync(
+            StripeCheckoutSessionRequestDto request,
             CancellationToken cancellationToken = default)
         {
             var secretKey = RequireSecretKey();
             var amountInCents = ConvertToStripeAmount(request.Amount, request.Currency);
 
-            using var message = new HttpRequestMessage(HttpMethod.Post, "v1/payouts");
+            using var message = new HttpRequestMessage(HttpMethod.Post, "v1/checkout/sessions");
             message.Headers.Authorization = new AuthenticationHeaderValue(
                 "Bearer",
                 secretKey);
 
-            if (!string.IsNullOrWhiteSpace(request.ConnectedAccountId))
-            {
-                message.Headers.Add("Stripe-Account", request.ConnectedAccountId);
-            }
-
             var fields = new Dictionary<string, string>
             {
-                ["amount"] = amountInCents.ToString(CultureInfo.InvariantCulture),
-                ["currency"] = request.Currency.ToLowerInvariant()
+                ["mode"] = "payment",
+                ["success_url"] = request.SuccessUrl,
+                ["cancel_url"] = request.CancelUrl,
+                ["line_items[0][quantity]"] = "1",
+                ["line_items[0][price_data][currency]"] = request.Currency.ToLowerInvariant(),
+                ["line_items[0][price_data][unit_amount]"] = amountInCents.ToString(CultureInfo.InvariantCulture),
+                ["line_items[0][price_data][product_data][name]"] = string.IsNullOrWhiteSpace(request.Description)
+                    ? "Rent a Car Payment"
+                    : request.Description
             };
 
-            if (!string.IsNullOrWhiteSpace(request.Description))
+            if (request.Metadata != null)
             {
-                fields["description"] = request.Description;
-            }
-
-            if (request.PaymentId.HasValue)
-            {
-                fields["metadata[paymentId]"] = request.PaymentId.Value.ToString(CultureInfo.InvariantCulture);
-            }
-
-            if (request.BookingId.HasValue)
-            {
-                fields["metadata[bookingId]"] = request.BookingId.Value.ToString(CultureInfo.InvariantCulture);
+                foreach (var kv in request.Metadata)
+                {
+                    fields[$"metadata[{kv.Key}]"] = kv.Value;
+                }
             }
 
             message.Content = new FormUrlEncodedContent(fields);
@@ -76,12 +71,12 @@ namespace RentACar.Application.Services
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning(
-                    "Stripe payout session creation failed with status {StatusCode}: {Response}",
+                    "Stripe checkout session creation failed with status {StatusCode}: {Response}",
                     response.StatusCode,
                     responseContent);
             }
 
-            return ParsePayoutSession(responseContent, request);
+            return ParseCheckoutSession(responseContent);
         }
 
         public StripeWebhookVerificationResultDto VerifyWebhookSignature(
@@ -179,55 +174,29 @@ namespace RentACar.Application.Services
             return (long)Math.Round(amount * 100m, 0, MidpointRounding.AwayFromZero);
         }
 
-        private static StripePayoutSessionDto ParsePayoutSession(string response, StripePayoutSessionRequestDto request)
+        private static StripeCheckoutSessionDto ParseCheckoutSession(string response)
         {
-            if (string.IsNullOrWhiteSpace(response))
-            {
-                return new StripePayoutSessionDto
-                {
-                    SessionId = string.Empty,
-                    Status = "unknown",
-                    Amount = request.Amount,
-                    Currency = request.Currency,
-                    ConnectedAccountId = request.ConnectedAccountId,
-                    CreatedAt = DateTime.UtcNow,
-                    RawResponse = response
-                };
-            }
-
             try
             {
                 using var document = JsonDocument.Parse(response);
                 var root = document.RootElement;
 
-                var createdUnix = root.TryGetProperty("created", out var createdElement) &&
-                                  createdElement.TryGetInt64(out var createdValue)
-                    ? DateTimeOffset.FromUnixTimeSeconds(createdValue).UtcDateTime
-                    : DateTime.UtcNow;
-
-                return new StripePayoutSessionDto
+                return new StripeCheckoutSessionDto
                 {
                     SessionId = root.TryGetProperty("id", out var idElement) ? idElement.GetString() ?? string.Empty : string.Empty,
-                    Status = root.TryGetProperty("status", out var statusElement) ? statusElement.GetString() ?? string.Empty : string.Empty,
-                    Amount = request.Amount,
-                    Currency = request.Currency,
-                    ConnectedAccountId = request.ConnectedAccountId,
-                    CreatedAt = createdUnix,
+                    CheckoutUrl = root.TryGetProperty("url", out var urlElement) ? urlElement.GetString() ?? string.Empty : string.Empty,
+                    Status = root.TryGetProperty("status", out var statusElement)
+                        ? statusElement.GetString() ?? string.Empty
+                        : string.Empty,
+                    PaymentIntentId = root.TryGetProperty("payment_intent", out var intentElement)
+                        ? intentElement.GetString()
+                        : null,
                     RawResponse = response
                 };
             }
             catch (JsonException)
             {
-                return new StripePayoutSessionDto
-                {
-                    SessionId = string.Empty,
-                    Status = "unknown",
-                    Amount = request.Amount,
-                    Currency = request.Currency,
-                    ConnectedAccountId = request.ConnectedAccountId,
-                    CreatedAt = DateTime.UtcNow,
-                    RawResponse = response
-                };
+                return new StripeCheckoutSessionDto { RawResponse = response };
             }
         }
 

--- a/RentACar.Application/Services/StripePaymentService.cs
+++ b/RentACar.Application/Services/StripePaymentService.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using RentACar.Application.DTOs;
+
+namespace RentACar.Application.Services
+{
+    public class StripePaymentService : IStripePaymentService
+    {
+        private const string StripeSecretKeyEnv = "STRIPE_PRIVATE_KEY";
+        private const string StripeWebhookSecretEnv = "STRIPE_WEBHOOK_SECRET";
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<StripePaymentService> _logger;
+        private readonly string? _secretKey;
+        private readonly string? _webhookSecret;
+
+        public StripePaymentService(HttpClient httpClient, ILogger<StripePaymentService> logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+            _secretKey = Environment.GetEnvironmentVariable(StripeSecretKeyEnv);
+            _webhookSecret = Environment.GetEnvironmentVariable(StripeWebhookSecretEnv);
+        }
+
+        public async Task<StripePayoutSessionDto> CreatePayoutSessionAsync(
+            StripePayoutSessionRequestDto request,
+            CancellationToken cancellationToken = default)
+        {
+            var secretKey = RequireSecretKey();
+            var amountInCents = ConvertToStripeAmount(request.Amount, request.Currency);
+
+            using var message = new HttpRequestMessage(HttpMethod.Post, "v1/payouts");
+            message.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                secretKey);
+
+            if (!string.IsNullOrWhiteSpace(request.ConnectedAccountId))
+            {
+                message.Headers.Add("Stripe-Account", request.ConnectedAccountId);
+            }
+
+            var fields = new Dictionary<string, string>
+            {
+                ["amount"] = amountInCents.ToString(CultureInfo.InvariantCulture),
+                ["currency"] = request.Currency.ToLowerInvariant()
+            };
+
+            if (!string.IsNullOrWhiteSpace(request.Description))
+            {
+                fields["description"] = request.Description;
+            }
+
+            if (request.PaymentId.HasValue)
+            {
+                fields["metadata[paymentId]"] = request.PaymentId.Value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (request.BookingId.HasValue)
+            {
+                fields["metadata[bookingId]"] = request.BookingId.Value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            message.Content = new FormUrlEncodedContent(fields);
+
+            using var response = await _httpClient.SendAsync(message, cancellationToken);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Stripe payout session creation failed with status {StatusCode}: {Response}",
+                    response.StatusCode,
+                    responseContent);
+            }
+
+            return ParsePayoutSession(responseContent, request);
+        }
+
+        public StripeWebhookVerificationResultDto VerifyWebhookSignature(
+            string payload,
+            string signatureHeader,
+            int toleranceSeconds = 300)
+        {
+            if (string.IsNullOrWhiteSpace(signatureHeader))
+            {
+                return new StripeWebhookVerificationResultDto
+                {
+                    IsValid = false,
+                    ErrorMessage = "Missing Stripe-Signature header."
+                };
+            }
+
+            var webhookSecret = RequireWebhookSecret();
+            var parsed = ParseSignatureHeader(signatureHeader);
+            if (!parsed.Timestamp.HasValue || parsed.Signatures.Count == 0)
+            {
+                return new StripeWebhookVerificationResultDto
+                {
+                    IsValid = false,
+                    ErrorMessage = "Invalid Stripe-Signature header."
+                };
+            }
+
+            var timestamp = parsed.Timestamp.Value;
+            var expected = ComputeSignature(webhookSecret, timestamp, payload);
+            var isValid = parsed.Signatures.Exists(sig => SecureEquals(sig, expected));
+
+            if (!isValid)
+            {
+                return new StripeWebhookVerificationResultDto
+                {
+                    IsValid = false,
+                    ErrorMessage = "Signature verification failed.",
+                    Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestamp)
+                };
+            }
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            if (Math.Abs(now - timestamp) > toleranceSeconds)
+            {
+                return new StripeWebhookVerificationResultDto
+                {
+                    IsValid = false,
+                    ErrorMessage = "Signature timestamp outside tolerance.",
+                    Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestamp)
+                };
+            }
+
+            return new StripeWebhookVerificationResultDto
+            {
+                IsValid = true,
+                Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestamp)
+            };
+        }
+
+        private string RequireSecretKey()
+        {
+            if (string.IsNullOrWhiteSpace(_secretKey))
+            {
+                throw new InvalidOperationException(
+                    $"Stripe secret key missing. Set environment variable {StripeSecretKeyEnv}.");
+            }
+
+            return _secretKey;
+        }
+
+        private string RequireWebhookSecret()
+        {
+            if (string.IsNullOrWhiteSpace(_webhookSecret))
+            {
+                throw new InvalidOperationException(
+                    $"Stripe webhook secret missing. Set environment variable {StripeWebhookSecretEnv}.");
+            }
+
+            return _webhookSecret;
+        }
+
+        private static long ConvertToStripeAmount(decimal amount, string currency)
+        {
+            var zeroDecimalCurrencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "bif", "clp", "djf", "gnf", "jpy", "kmf", "krw", "mga",
+                "pyg", "rwf", "ugx", "vnd", "vuv", "xaf", "xof", "xpf"
+            };
+
+            if (zeroDecimalCurrencies.Contains(currency))
+            {
+                return (long)Math.Round(amount, 0, MidpointRounding.AwayFromZero);
+            }
+
+            return (long)Math.Round(amount * 100m, 0, MidpointRounding.AwayFromZero);
+        }
+
+        private static StripePayoutSessionDto ParsePayoutSession(string response, StripePayoutSessionRequestDto request)
+        {
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                return new StripePayoutSessionDto
+                {
+                    SessionId = string.Empty,
+                    Status = "unknown",
+                    Amount = request.Amount,
+                    Currency = request.Currency,
+                    ConnectedAccountId = request.ConnectedAccountId,
+                    CreatedAt = DateTime.UtcNow,
+                    RawResponse = response
+                };
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(response);
+                var root = document.RootElement;
+
+                var createdUnix = root.TryGetProperty("created", out var createdElement) &&
+                                  createdElement.TryGetInt64(out var createdValue)
+                    ? DateTimeOffset.FromUnixTimeSeconds(createdValue).UtcDateTime
+                    : DateTime.UtcNow;
+
+                return new StripePayoutSessionDto
+                {
+                    SessionId = root.TryGetProperty("id", out var idElement) ? idElement.GetString() ?? string.Empty : string.Empty,
+                    Status = root.TryGetProperty("status", out var statusElement) ? statusElement.GetString() ?? string.Empty : string.Empty,
+                    Amount = request.Amount,
+                    Currency = request.Currency,
+                    ConnectedAccountId = request.ConnectedAccountId,
+                    CreatedAt = createdUnix,
+                    RawResponse = response
+                };
+            }
+            catch (JsonException)
+            {
+                return new StripePayoutSessionDto
+                {
+                    SessionId = string.Empty,
+                    Status = "unknown",
+                    Amount = request.Amount,
+                    Currency = request.Currency,
+                    ConnectedAccountId = request.ConnectedAccountId,
+                    CreatedAt = DateTime.UtcNow,
+                    RawResponse = response
+                };
+            }
+        }
+
+        private static StripeSignatureHeader ParseSignatureHeader(string signatureHeader)
+        {
+            var result = new StripeSignatureHeader();
+            var parts = signatureHeader.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var part in parts)
+            {
+                var kv = part.Split('=', 2, StringSplitOptions.RemoveEmptyEntries);
+                if (kv.Length != 2)
+                {
+                    continue;
+                }
+
+                if (kv[0] == "t" && long.TryParse(kv[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var timestamp))
+                {
+                    result.Timestamp = timestamp;
+                    continue;
+                }
+
+                if (kv[0] == "v1")
+                {
+                    result.Signatures.Add(kv[1]);
+                }
+            }
+
+            return result;
+        }
+
+        private static string ComputeSignature(string secret, long timestamp, string payload)
+        {
+            var signedPayload = $"{timestamp}.{payload}";
+            var keyBytes = Encoding.UTF8.GetBytes(secret);
+            var payloadBytes = Encoding.UTF8.GetBytes(signedPayload);
+            using var hmac = new HMACSHA256(keyBytes);
+            var hash = hmac.ComputeHash(payloadBytes);
+            return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static bool SecureEquals(string left, string right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            var result = 0;
+            for (var i = 0; i < left.Length; i++)
+            {
+                result |= left[i] ^ right[i];
+            }
+
+            return result == 0;
+        }
+
+        private sealed class StripeSignatureHeader
+        {
+            public long? Timestamp { get; set; }
+
+            public List<string> Signatures { get; } = new();
+        }
+    }
+}

--- a/RentACar.Core/Entities/Payment.cs
+++ b/RentACar.Core/Entities/Payment.cs
@@ -33,6 +33,21 @@ public partial class Payment
     [Unicode(false)]
     public string? Status { get; set; }
 
+    [Column("paymentProvider")]
+    [StringLength(30)]
+    [Unicode(false)]
+    public string? PaymentProvider { get; set; }
+
+    [Column("paymentProviderSessionId")]
+    [StringLength(100)]
+    [Unicode(false)]
+    public string? PaymentProviderSessionId { get; set; }
+
+    [Column("paymentProviderPaymentIntentId")]
+    [StringLength(100)]
+    [Unicode(false)]
+    public string? PaymentProviderPaymentIntentId { get; set; }
+
     [ForeignKey("BookingId")]
     public virtual Booking Booking { get; set; } = null!;
 

--- a/RentACar.Infrastructure/Data/Repository/StripePaymentService.cs
+++ b/RentACar.Infrastructure/Data/Repository/StripePaymentService.cs
@@ -1,0 +1,66 @@
+
+using Stripe;
+using Stripe.Checkout;
+using RentACar.Core.Repositories.Base;
+using RentACar.Core.Repositories;
+using Microsoft.Extensions.Configuration;
+
+namespace RentACar.Infrastructure.Repository.Base
+{
+    public class StripePaymentService : IStripePaymentService
+    {
+        public StripePaymentService(IConfiguration config)
+        {
+            StripeConfiguration.ApiKey = config["Stripe:SecretKey"];
+        }
+
+        public async Task<(string SessionId, string CheckoutUrl)> CreateCheckoutSessionAsync(
+            decimal amountUsd,
+            string description,
+            string successUrl,
+            string cancelUrl,
+            Dictionary<string, string>? metadata = null)
+        {
+            var amountCents = (long)Math.Round(amountUsd * 100m);
+
+            var options = new SessionCreateOptions
+            {
+                Mode = "payment",
+                SuccessUrl = successUrl,
+                CancelUrl = cancelUrl,
+                PaymentMethodTypes = new List<string> { "card" },
+                LineItems = new List<SessionLineItemOptions>
+                {
+                    new SessionLineItemOptions
+                    {
+                        Quantity = 1,
+                        PriceData = new SessionLineItemPriceDataOptions
+                        {
+                            Currency = "usd",
+                            UnitAmount = amountCents,
+                            ProductData = new SessionLineItemPriceDataProductDataOptions
+                            {
+                                Name = description
+                            }
+                        }
+                    }
+                },
+                Metadata = metadata
+            };
+
+            var service = new SessionService();
+            var session = await service.CreateAsync(options);
+
+            return (session.Id, session.Url);
+        }
+
+        public async Task<bool> IsSessionPaidAsync(string sessionId)
+        {
+            var service = new SessionService();
+            var session = await service.GetAsync(sessionId);
+
+            // payment_status is "paid" when successful
+            return string.Equals(session.PaymentStatus, "paid", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/RentACar.Infrastructure/RentACar.Infrastructure.csproj
+++ b/RentACar.Infrastructure/RentACar.Infrastructure.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Stripe.net" Version="50.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RentACar.Web/Controllers/BookingController.cs
+++ b/RentACar.Web/Controllers/BookingController.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using RentACar.Web.Models;
+using System.Security.Claims;
 
 namespace RentACar.Web.Controllers
 {
@@ -214,6 +215,40 @@ namespace RentACar.Web.Controllers
             }
 
             return Ok(result);
+        }
+
+        [HttpPost("Pay")]
+        public async Task<IActionResult> Pay([FromBody] MakePaymentRequestDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Unauthorized();
+            }
+
+            var customer = await _customerManager.GetCustomerByAspNetUserId(userId);
+            if (customer == null)
+            {
+                return Unauthorized();
+            }
+
+            var result = await _paymentManager.MakePaymentByCustomerAsync(dto, customer.UserId);
+            if (result == null)
+            {
+                return BadRequest("Unable to process payment request.");
+            }
+
+            if (result.RequiresRedirect && !string.IsNullOrWhiteSpace(result.RedirectUrl))
+            {
+                return Redirect(result.RedirectUrl);
+            }
+
+            return Ok(result.Payment);
         }
 
         [HttpGet("{id}")]

--- a/RentACar.Web/Controllers/StripeController.cs
+++ b/RentACar.Web/Controllers/StripeController.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using RentACar.Application.Managers;
+using RentACar.Application.Services;
+
+namespace RentACar.Web.Controllers
+{
+    [ApiController]
+    [Route("Stripe")]
+    public class StripeController : Controller
+    {
+        private readonly IStripePaymentService _stripePaymentService;
+        private readonly PaymentManager _paymentManager;
+        private readonly ILogger<StripeController> _logger;
+
+        public StripeController(
+            IStripePaymentService stripePaymentService,
+            PaymentManager paymentManager,
+            ILogger<StripeController> logger)
+        {
+            _stripePaymentService = stripePaymentService;
+            _paymentManager = paymentManager;
+            _logger = logger;
+        }
+
+        [HttpPost("Webhook")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Webhook()
+        {
+            string payload;
+            using (var reader = new StreamReader(Request.Body))
+            {
+                payload = await reader.ReadToEndAsync();
+            }
+
+            var signatureHeader = Request.Headers["Stripe-Signature"].ToString();
+            var verification = _stripePaymentService.VerifyWebhookSignature(payload, signatureHeader);
+            if (!verification.IsValid)
+            {
+                _logger.LogWarning("Stripe webhook signature invalid: {Error}", verification.ErrorMessage);
+                return BadRequest();
+            }
+
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return BadRequest();
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(payload);
+                var root = document.RootElement;
+                var eventType = root.GetProperty("type").GetString();
+                if (!string.Equals(eventType, "checkout.session.completed", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Ok();
+                }
+
+                var session = root.GetProperty("data").GetProperty("object");
+                var metadata = session.TryGetProperty("metadata", out var metadataElement)
+                    ? metadataElement
+                    : default;
+
+                if (metadata.ValueKind == JsonValueKind.Undefined ||
+                    !metadata.TryGetProperty("paymentId", out var paymentIdElement) ||
+                    !int.TryParse(paymentIdElement.GetString(), out var paymentId))
+                {
+                    _logger.LogWarning("Stripe webhook missing paymentId metadata.");
+                    return Ok();
+                }
+
+                var paymentIntentId = session.TryGetProperty("payment_intent", out var intentElement)
+                    ? intentElement.GetString()
+                    : null;
+                var sessionId = session.TryGetProperty("id", out var sessionIdElement)
+                    ? sessionIdElement.GetString()
+                    : null;
+
+                await _paymentManager.MarkPaymentPaidAsync(paymentId, paymentIntentId, sessionId);
+                return Ok();
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Stripe webhook payload invalid.");
+                return BadRequest();
+            }
+        }
+
+        [HttpGet("Success")]
+        [AllowAnonymous]
+        public IActionResult Success()
+        {
+            return RedirectToAction("Index", "Home");
+        }
+
+        [HttpGet("Cancel")]
+        [AllowAnonymous]
+        public IActionResult Cancel()
+        {
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/RentACar.Web/Program.cs
+++ b/RentACar.Web/Program.cs
@@ -9,6 +9,7 @@ using RentACar.Infrastructure.Repositories;
 using AutoMapper;
 using RentACar.Infrastructure.Data.Repositories;
 using RentACar.Application.Managers;
+using RentACar.Application.Services;
 using Serilog;
 using QuestPDF.Infrastructure;
 
@@ -67,6 +68,10 @@ builder.Services.AddScoped<IPromocodeRepository, PromocodeRepository>();
 builder.Services.AddScoped<IPaymentMethodRepository, PaymentMethodRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
 builder.Services.AddHttpClient<IEmailService, MailjetEmailService>();
+builder.Services.AddHttpClient<IStripePaymentService, StripePaymentService>(client =>
+{
+    client.BaseAddress = new Uri("https://api.stripe.com/");
+});
 
 // ✅ Register managers
 builder.Services.AddScoped<CustomerManager>();

--- a/RentACar.Web/RentACar.Web.csproj
+++ b/RentACar.Web/RentACar.Web.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="QuestPDF" Version="2024.3.0" />
+    <PackageReference Include="Stripe.net" Version="50.1.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
### Motivation
- Add support for creating Stripe payout sessions and verifying webhook signatures for provider-driven payouts.
- Persist provider identifiers on payments so external payment sessions and intents can be referenced from the system.
- Keep secret configuration out of source code by using environment variables for the Stripe private key and webhook secret (`STRIPE_PRIVATE_KEY`, `STRIPE_WEBHOOK_SECRET`).
- Register a typed HTTP client so the application can call the Stripe API securely.

### Description
- Added DTOs for payout requests and responses and webhook verification results in `RentACar.Application/DTOs/StripePayoutSessionDto.cs`.
- Introduced `IStripePaymentService` and `StripePaymentService` in `RentACar.Application/Services` implementing `CreatePayoutSessionAsync` and `VerifyWebhookSignature`, and the service reads `STRIPE_PRIVATE_KEY` and `STRIPE_WEBHOOK_SECRET` from environment variables.
- Extended the `Payment` entity with `PaymentProvider`, `PaymentProviderSessionId`, and `PaymentProviderPaymentIntentId`, and added corresponding fields to `PaymentDto` and `PaymentDetailsDto` and wired them into `PaymentManager` mapping and persistence.
- Registered the Stripe payment service in the web DI container as an `HttpClient` with base address `https://api.stripe.com/` in `RentACar.Web/Program.cs`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69660d154f708320a2d0f3e8613facbe)