### PR TITLE
Add customer Stripe Checkout flow and MyBookings payment UI

### DIFF
--- a/RentACar.Application/DTOs/BookingDto.cs
+++ b/RentACar.Application/DTOs/BookingDto.cs
@@ -33,10 +33,6 @@ namespace RentACar.Application.DTOs
         [StringLength(50)]
         public string BookingStatus { get; set; } = "pending";
 
-        [Required]
-        public int? PaymentId { get; set; }
-
-
         [Range(0.01, double.MaxValue, ErrorMessage = "Subtotal must be greater than 0.")]
         public decimal? Subtotal { get; set; }
     }

--- a/RentACar.Application/Managers/BookingManager.cs
+++ b/RentACar.Application/Managers/BookingManager.cs
@@ -175,8 +175,7 @@ namespace RentACar.Application.Managers
                 BookingStatus = "Pending",
                 Subtotal = subtotal,
                 IsBookedByEmployee = isBookedByEmployee,
-                EmployeebookerId = isBookedByEmployee ? employeeBookerIntId : null,
-                PaymentId = 0
+                EmployeebookerId = isBookedByEmployee ? employeeBookerIntId : null
             };
 
             // Save booking first to generate BookingId
@@ -196,10 +195,6 @@ namespace RentACar.Application.Managers
             };
 
             var addedPayment = await _paymentRepository.AddAsync(payment);
-
-            // Link payment back to booking
-            addedBooking.PaymentId = addedPayment.PaymentId;
-            await _bookingRepository.UpdateAsync(addedBooking);
 
             _logger.LogInformation("✅ Booking created with ID: {BookingId}", addedBooking.BookingId);
             

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -60,6 +60,28 @@ namespace RentACar.Application.Managers
             if (booking == null || booking.CustomerId != customerUserId)
                 return null;
 
+            var existingPayments = await _paymentRepository.GetPaymentsByBookingIdAsync(paymentDto.BookingId);
+            if (existingPayments.Any())
+            {
+                var latestPayment = existingPayments
+                    .OrderByDescending(p => p.PaymentDate)
+                    .ThenByDescending(p => p.PaymentId)
+                    .First();
+                _logger.LogInformation("Payment already exists for booking {BookingId}. Returning existing payment {PaymentId}.",
+                    paymentDto.BookingId, latestPayment.PaymentId);
+                var existingDto = _mapper.Map<PaymentDto>(latestPayment);
+                var methodId = await ResolvePaymentMethodIdAsync(latestPayment.PaymentMethod);
+                if (methodId.HasValue)
+                {
+                    existingDto.PaymentMethodId = methodId.Value;
+                }
+                return new MakePaymentResultDto
+                {
+                    Payment = existingDto,
+                    RequiresRedirect = false
+                };
+            }
+
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(paymentDto.PaymentMethodId);
             if (paymentMethod == null)
                 return null;
@@ -202,6 +224,12 @@ namespace RentACar.Application.Managers
             {
                 _logger.LogWarning("Stripe webhook received for missing payment {PaymentId}", paymentId);
                 return false;
+            }
+
+            if (string.Equals(payment.Status, "done", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("Stripe webhook received for already completed payment {PaymentId}", paymentId);
+                return true;
             }
 
             payment.Status = "done";

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -67,20 +67,27 @@ namespace RentACar.Application.Managers
                     .OrderByDescending(p => p.PaymentDate)
                     .ThenByDescending(p => p.PaymentId)
                     .First();
-                _logger.LogInformation("Payment already exists for booking {BookingId}. Returning existing payment {PaymentId}.",
-                    paymentDto.BookingId, latestPayment.PaymentId);
-                var existingDto = _mapper.Map<PaymentDto>(latestPayment);
-                var methodId = await ResolvePaymentMethodIdAsync(latestPayment.PaymentMethod);
-                if (methodId.HasValue)
+
+                // ✅ If already paid, don't redirect
+                if (string.Equals(latestPayment.Status, "done", StringComparison.OrdinalIgnoreCase))
                 {
-                    existingDto.PaymentMethodId = methodId.Value;
+                    var paidDto = _mapper.Map<PaymentDto>(latestPayment);
+
+                    var methodId = await ResolvePaymentMethodIdAsync(latestPayment.PaymentMethod);
+                    if (methodId.HasValue) paidDto.PaymentMethodId = methodId.Value;
+
+                    return new MakePaymentResultDto
+                    {
+                        Payment = paidDto,
+                        RequiresRedirect = false,
+                        RedirectUrl = null
+                    };
                 }
-                return new MakePaymentResultDto
-                {
-                    Payment = existingDto,
-                    RequiresRedirect = false
-                };
+
+                // ✅ If NOT paid yet (unpaid/pending), continue to create Stripe session (redirect)
+                // so DO NOT return here
             }
+
 
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(paymentDto.PaymentMethodId);
             if (paymentMethod == null)

--- a/RentACar.Core/Entities/Booking.cs
+++ b/RentACar.Core/Entities/Booking.cs
@@ -38,9 +38,6 @@ public partial class Booking
     [StringLength(50)]
     public string? BookingStatus { get; set; }
 
-    [Column("paymentID")]
-    public int? PaymentId { get; set; } // keep the column for reference (nullable)
-
     [Column("subtotal", TypeName = "decimal(18, 2)")]
     public decimal? Subtotal { get; set; }
 
@@ -60,5 +57,5 @@ public partial class Booking
     [InverseProperty("Bookings")]
     public virtual Promocode? Promocode { get; set; }
 
-    // ❌ Removed Payment navigation to prevent circular FK
+    public virtual Payment? Payment { get; set; }
 }

--- a/RentACar.Infrastructure/Data/RentACarDbContext.cs
+++ b/RentACar.Infrastructure/Data/RentACarDbContext.cs
@@ -126,9 +126,10 @@ public partial class RentACarDbContext : DbContext
         modelBuilder.Entity<Payment>(entity =>
         {
             entity.HasOne(d => d.Booking)
-                .WithOne() // No navigation in Booking
+                .WithOne(b => b.Payment)
                 .HasForeignKey<Payment>(p => p.BookingId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade)
                 .HasConstraintName("FK_Payments_Bookings");
         });
 

--- a/RentACar.Infrastructure/Migrations/RentACarDbContextModelSnapshot.cs
+++ b/RentACar.Infrastructure/Migrations/RentACarDbContextModelSnapshot.cs
@@ -355,10 +355,6 @@ namespace RentACar.Infrastructure.Migrations
                         .HasDefaultValue(false)
                         .HasColumnName("isBookedByEmployee");
 
-                    b.Property<int?>("PaymentId")
-                        .HasColumnType("int")
-                        .HasColumnName("paymentID");
-
                     b.Property<int?>("PromocodeId")
                         .HasColumnType("int")
                         .HasColumnName("promocodeID");
@@ -855,6 +851,8 @@ namespace RentACar.Infrastructure.Migrations
 
                     b.Navigation("Employeebooker");
 
+                    b.Navigation("Payment");
+
                     b.Navigation("Promocode");
                 });
 
@@ -912,9 +910,10 @@ namespace RentACar.Infrastructure.Migrations
             modelBuilder.Entity("RentACar.Core.Entities.Payment", b =>
                 {
                     b.HasOne("RentACar.Core.Entities.Booking", "Booking")
-                        .WithOne()
+                        .WithOne("Payment")
                         .HasForeignKey("RentACar.Core.Entities.Payment", "BookingId")
                         .IsRequired()
+                        .OnDelete(DeleteBehavior.Cascade)
                         .HasConstraintName("FK_Payments_Bookings");
 
                     b.Navigation("Booking");

--- a/RentACar.Web/Controllers/BookingController.cs
+++ b/RentACar.Web/Controllers/BookingController.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using RentACar.Web.Models;
 using System.Security.Claims;
+using System.Linq;
 
 namespace RentACar.Web.Controllers
 {
@@ -129,9 +130,11 @@ namespace RentACar.Web.Controllers
             var employee = booking.EmployeebookerId.HasValue
                 ? await _employeeManager.GetEmployeeById(booking.EmployeebookerId.Value)
                 : null;
-            var payment = booking.PaymentId.HasValue
-                ? await _paymentManager.GetPaymentByIdAsync(booking.PaymentId.Value)
-                : null;
+            var payments = await _paymentManager.GetPaymentsByBookingIdAsync(booking.BookingId);
+            var payment = payments
+                .OrderByDescending(p => p.PaymentDate)
+                .ThenByDescending(p => p.PaymentId)
+                .FirstOrDefault();
             var promo = booking.PromocodeId.HasValue
                 ? await _promocodeManager.GetPromocodeByIdAsync(booking.PromocodeId.Value)
                 : null;
@@ -155,7 +158,7 @@ namespace RentACar.Web.Controllers
                 CarColor = car?.Color,
                 CarModelYear = car?.ModelYear,
                 CarPricePerDay = car?.PricePerDay,
-                PaymentId = booking.PaymentId,
+                PaymentId = payment?.PaymentId,
                 PaymentAmount = payment?.Amount,
                 PromocodeName = promo?.Name,
                 PromocodeDiscount = promo?.DiscountPercentage
@@ -178,9 +181,11 @@ namespace RentACar.Web.Controllers
                 var employee = b.EmployeebookerId.HasValue
                     ? await _employeeManager.GetEmployeeById(b.EmployeebookerId.Value)
                     : null;
-                var payment = b.PaymentId.HasValue
-                    ? await _paymentManager.GetPaymentByIdAsync(b.PaymentId.Value)
-                    : null;
+                var payments = await _paymentManager.GetPaymentsByBookingIdAsync(b.BookingId);
+                var payment = payments
+                    .OrderByDescending(p => p.PaymentDate)
+                    .ThenByDescending(p => p.PaymentId)
+                    .FirstOrDefault();
                 var promo = b.PromocodeId.HasValue
                     ? await _promocodeManager.GetPromocodeByIdAsync(b.PromocodeId.Value)
                     : null;
@@ -201,7 +206,7 @@ namespace RentACar.Web.Controllers
                     carPricePerDay = car?.PricePerDay,
                     employeebookerId = b.EmployeebookerId,
                     employeeName = employee?.Name,
-                    paymentId = b.PaymentId,
+                    paymentId = payment?.PaymentId,
                     paymentAmount = payment?.Amount,
                     subtotal = b.Subtotal,
                     totalPrice = b.TotalPrice,
@@ -345,8 +350,11 @@ namespace RentACar.Web.Controllers
             var car = await _carManager.GetCarByIdAsync(booking.CarId);
             var customer = await _customerManager.GetCustomerById(booking.CustomerId);
             PaymentDto? payment = null;
-            if (booking.PaymentId.HasValue)
-                payment = await _paymentManager.GetPaymentByIdAsync(booking.PaymentId.Value);
+            var payments = await _paymentManager.GetPaymentsByBookingIdAsync(booking.BookingId);
+            payment = payments
+                .OrderByDescending(p => p.PaymentDate)
+                .ThenByDescending(p => p.PaymentId)
+                .FirstOrDefault();
             PromocodeDto? promo = null;
             if (booking.PromocodeId.HasValue)
                 promo = await _promocodeManager.GetPromocodeByIdAsync(booking.PromocodeId.Value);

--- a/RentACar.Web/Controllers/BookingsController.cs
+++ b/RentACar.Web/Controllers/BookingsController.cs
@@ -5,6 +5,7 @@ using RentACar.Application.DTOs;
 using RentACar.Application.Managers;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
+using System.Linq;
 
 namespace RentACar.Web.Controllers
 {
@@ -59,17 +60,43 @@ namespace RentACar.Web.Controllers
             foreach (var b in bookings)
             {
                 var car = await _carManager.GetCarByIdAsync(b.CarId);
+                var payments = await _paymentManager.GetPaymentsByBookingIdAsync(b.BookingId);
+                var latestPayment = payments
+                    .OrderByDescending(p => p.PaymentDate)
+                    .ThenByDescending(p => p.PaymentId)
+                    .FirstOrDefault();
                 result.Add(new
                 {
                     bookingId = b.BookingId,
                     carName = car?.ModelName,
                     plateNumber = car?.PlateNumber,
-                    paymentId = b.PaymentId,
+                    paymentId = latestPayment?.PaymentId,
+                    paymentStatus = latestPayment?.Status,
                     startdate = b.Startdate.ToString("yyyy-MM-dd"),
                     enddate = b.Enddate.ToString("yyyy-MM-dd"),
                     totalPrice = b.TotalPrice
                 });
             }
+            return Ok(result);
+        }
+
+        [HttpPost("Pay")]
+        public async Task<IActionResult> Pay([FromBody] MakePaymentRequestDto request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var customerId = await GetCurrentCustomerId();
+            if (customerId == null) return Unauthorized();
+
+            var result = await _paymentManager.MakePaymentByCustomerAsync(request, customerId.Value);
+            if (result == null)
+            {
+                return BadRequest("Unable to process payment.");
+            }
+
             return Ok(result);
         }
 

--- a/RentACar.Web/Controllers/BookingsController.cs
+++ b/RentACar.Web/Controllers/BookingsController.cs
@@ -111,8 +111,11 @@ namespace RentACar.Web.Controllers
 
             var car = await _carManager.GetCarByIdAsync(booking.CarId);
             PaymentDto? payment = null;
-            if (booking.PaymentId.HasValue)
-                payment = await _paymentManager.GetPaymentByIdAsync(booking.PaymentId.Value);
+            var payments = await _paymentManager.GetPaymentsByBookingIdAsync(booking.BookingId);
+            payment = payments
+                .OrderByDescending(p => p.PaymentDate)
+                .ThenByDescending(p => p.PaymentId)
+                .FirstOrDefault();
 
             var bytes = GenerateTicketPdf(booking, car, payment);
             return File(bytes, "application/pdf", $"booking_{id}.pdf");

--- a/RentACar.Web/Controllers/PaymentController.cs
+++ b/RentACar.Web/Controllers/PaymentController.cs
@@ -1,153 +1,153 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using RentACar.Application.DTOs;
-using RentACar.Application.Managers;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using RentACar.Application.DTOs;
+    using RentACar.Application.Managers;
 
-namespace RentACar.Web.Controllers
-{
-    [Authorize(Roles = "Admin,Employee")]
-    [ApiController]
-    [Route("api/[controller]")]
-    public class PaymentController : Controller
+    namespace RentACar.Web.Controllers
     {
-        private readonly PaymentManager _paymentManager;
-        private readonly PromocodeManager _promocodeManager;
-        private readonly ILogger<PaymentController> _logger;
-
-        public PaymentController(PaymentManager paymentManager, PromocodeManager promocodeManager, ILogger<PaymentController> logger)
+        [Authorize(Roles = "Admin,Employee")]
+        [ApiController]
+        [Route("api/[controller]")]
+        public class PaymentController : Controller
         {
-            _paymentManager = paymentManager;
-            _promocodeManager = promocodeManager;
-            _logger = logger;
-        }
+            private readonly PaymentManager _paymentManager;
+            private readonly PromocodeManager _promocodeManager;
+            private readonly ILogger<PaymentController> _logger;
 
-        [HttpGet("~/Payment")]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public IActionResult Index()
-        {
-            return View("~/Views/ControlPanel/Payment/Index.cshtml");
-        }
-
-        [HttpGet("~/Payment/Add")]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public IActionResult AddView()
-        {
-            return View("~/Views/ControlPanel/Payment/Add.cshtml", new PaymentDto
+            public PaymentController(PaymentManager paymentManager, PromocodeManager promocodeManager, ILogger<PaymentController> logger)
             {
-                PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow)
-            });
-        }
-
-        [HttpGet("~/Payment/Edit/{id}")]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public async Task<IActionResult> EditView(int id)
-        {
-            var payment = await _paymentManager.GetPaymentForEditAsync(id);
-            if (payment == null)
-            {
-                return NotFound();
+                _paymentManager = paymentManager;
+                _promocodeManager = promocodeManager;
+                _logger = logger;
             }
 
-            return View("~/Views/ControlPanel/Payment/Edit.cshtml", payment);
-        }
-
-        [HttpGet("~/Payment/Details/{id}")]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public async Task<IActionResult> DetailsView(int id)
-        {
-            var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
-            if (payment == null)
+            [HttpGet("~/Payment")]
+            [ApiExplorerSettings(IgnoreApi = true)]
+            public IActionResult Index()
             {
-                return NotFound();
+                return View("~/Views/ControlPanel/Payment/Index.cshtml");
             }
 
-            return View("~/Views/ControlPanel/Payment/Details.cshtml", payment);
-        }
-
-        [HttpGet]
-        public async Task<ActionResult<IEnumerable<PaymentDetailsDto>>> Get()
-        {
-            var payments = await _paymentManager.GetAllPaymentsWithDetailsAsync();
-            return Ok(payments);
-        }
-
-        [HttpGet("{id}")]
-        public async Task<ActionResult<PaymentDetailsDto>> Get(int id)
-        {
-            var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
-            if (payment == null)
+            [HttpGet("~/Payment/Add")]
+            [ApiExplorerSettings(IgnoreApi = true)]
+            public IActionResult AddView()
             {
-                return NotFound();
+                return View("~/Views/ControlPanel/Payment/Add.cshtml", new PaymentDto
+                {
+                    PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow)
+                });
             }
 
-            return Ok(payment);
-        }
-
-        [HttpPost]
-        public async Task<ActionResult<PaymentDto>> Create([FromBody] PaymentDto dto)
-        {
-            if (!ModelState.IsValid)
+            [HttpGet("~/Payment/Edit/{id}")]
+            [ApiExplorerSettings(IgnoreApi = true)]
+            public async Task<IActionResult> EditView(int id)
             {
-                return BadRequest(ModelState);
+                var payment = await _paymentManager.GetPaymentForEditAsync(id);
+                if (payment == null)
+                {
+                    return NotFound();
+                }
+
+                return View("~/Views/ControlPanel/Payment/Edit.cshtml", payment);
             }
 
-            var created = await _paymentManager.AddPaymentAsync(dto);
-            if (created == null)
+            [HttpGet("~/Payment/Details/{id}")]
+            [ApiExplorerSettings(IgnoreApi = true)]
+            public async Task<IActionResult> DetailsView(int id)
             {
-                _logger.LogWarning("Failed to create payment for booking {BookingId}", dto.BookingId);
-                return BadRequest("Unable to create payment. Please verify booking and payment method.");
+                var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+                if (payment == null)
+                {
+                    return NotFound();
+                }
+
+                return View("~/Views/ControlPanel/Payment/Details.cshtml", payment);
             }
 
-            return CreatedAtAction(nameof(Get), new { id = created.PaymentId }, created);
-        }
-
-        [HttpPut("{id}")]
-        public async Task<IActionResult> Update(int id, [FromBody] PaymentDto dto)
-        {
-            if (id != dto.PaymentId)
+            [HttpGet]
+            public async Task<ActionResult<IEnumerable<PaymentDetailsDto>>> Get()
             {
-                return BadRequest("ID mismatch");
+                var payments = await _paymentManager.GetAllPaymentsWithDetailsAsync();
+                return Ok(payments);
             }
 
-            var updated = await _paymentManager.UpdatePaymentAsync(dto);
-            if (updated == null)
+            [HttpGet("{id}")]
+            public async Task<ActionResult<PaymentDetailsDto>> Get(int id)
             {
-                return NotFound();
+                var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+                if (payment == null)
+                {
+                    return NotFound();
+                }
+
+                return Ok(payment);
             }
 
-            return NoContent();
-        }
+            [HttpPost]
+            public async Task<ActionResult<PaymentDto>> Create([FromBody] PaymentDto dto)
+            {
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
 
-        [HttpGet("ApplyPromocode/{id}")]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public async Task<IActionResult> ApplyPromocodeView(int id)
-        {
-            var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
-            if (payment == null) return NotFound();
+                var created = await _paymentManager.AddPaymentAsync(dto);
+                if (created == null)
+                {
+                    _logger.LogWarning("Failed to create payment for booking {BookingId}", dto.BookingId);
+                    return BadRequest("Unable to create payment. Please verify booking and payment method.");
+                }
 
-            // Get current user ID to fetch visible promocodes
-            var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
-            var allPromos = await _promocodeManager.GetAllPromocodesAsync(userId);
-            // Filter only active ones for the dropdown
-            var activePromos = allPromos.Where(p => p.IsActive).ToList();
+                return CreatedAtAction(nameof(Get), new { id = created.PaymentId }, created);
+            }
 
-            ViewBag.PaymentId = id;
-            var model = new PromocodeDto(); // Using PromocodeDto as model for key selection, or just ViewBag
-            // Better to pass a ViewModel, but for speed I'll use ViewBag for the list and an empty DTO or similar.
-            // Actually, the partial probably expects a specific model?
-            // User said: "_applypromocode, contains form which have dropdown list contains all the names of the active promocodes ... and submit button"
-            
-            ViewBag.ActivePromocodes = activePromos;
-            return PartialView("~/Views/ControlPanel/Payment/_ApplyPromocode.cshtml");
-        }
+            [HttpPut("{id}")]
+            public async Task<IActionResult> Update(int id, [FromBody] PaymentDto dto)
+            {
+                if (id != dto.PaymentId)
+                {
+                    return BadRequest("ID mismatch");
+                }
 
-        [HttpPost("ApplyPromocode/{id}")]
-        public async Task<IActionResult> ApplyPromocode(int id, [FromForm] int promocodeId)
-        {
+                var updated = await _paymentManager.UpdatePaymentAsync(dto);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+
+                return NoContent();
+            }
+
+            [HttpGet("ApplyPromocode/{id}")]
+            [ApiExplorerSettings(IgnoreApi = true)]
+            public async Task<IActionResult> ApplyPromocodeView(int id)
+            {
+                var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+                if (payment == null) return NotFound();
+
+                // Get current user ID to fetch visible promocodes
+                var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+                var allPromos = await _promocodeManager.GetAllPromocodesAsync(userId);
+                // Filter only active ones for the dropdown
+                var activePromos = allPromos.Where(p => p.IsActive).ToList();
+
+                ViewBag.PaymentId = id;
+                var model = new PromocodeDto(); // Using PromocodeDto as model for key selection, or just Vie
+                                            // Better to pass a ViewModel, but for speed I'll use ViewBag for the list and an empty DTO or similar.
+                                            // Actually, the partial probably expects a specific model?
+                                            // User said: "_applypromocode, contains form which have dropdown list contains all the names of the active promocodes ... and submit button"
+   
+                ViewBag.ActivePromocodes = activePromos;
+                return PartialView("~/Views/ControlPanel/Payment/_ApplyPromocode.cshtml");
+            }
+
+            [HttpPost("ApplyPromocode/{id}")]
+            public async Task<IActionResult> ApplyPromocode(int id, [FromForm] int promocodeId)
+         
             // Logic to apply promocode. 
             // Since there is no existing method in PaymentManager exposed here, I will implement a basic logic or placeholder.
             // Requirement says: "add apply promocode in action".
@@ -156,16 +156,16 @@ namespace RentACar.Web.Controllers
             // I'll try to do something meaningful if possible, otherwise just success.
             // Payment usually has a BookingId. Promo applies to Booking?
             // Payment table has 'Promo Code' column.
-            
-            // I'll assume for now we just want the UI flow.
-             try
-            {
-                 // Fetch payment to verify existence
-                var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
-                if (payment == null) return NotFound();
 
-                var promo = await _promocodeManager.GetPromocodeByIdAsync(promocodeId);
-                if (promo == null) return BadRequest("Invalid Promocode");
+            // I'll assume for now we just want the UI flow.
+            try
+            {
+                // Fetch payment to verify existencece
+                    var payment = await _paymentManager.GetPaymentDetailsByIdAsync(id);
+                    if (payment == null) return NotFound();
+
+                    var promo = await _promocodeManager.GetPromocodeByIdAsync(promocodeId);
+                    if (promo == null) return BadRequest("Invalid Promocod
 
                 // Here we would typically update the Booking or Payment with the Promo.
                 // Since I don't have a direct 'ApplyPromoToPayment' method in the Manager shown,
@@ -176,19 +176,19 @@ namespace RentACar.Web.Controllers
                 // `public string? PromocodeName { get; set; }`
                 // `public decimal? PromocodeDiscountPercentage { get; set; }`
                 // These are likely derived from Booking or stored on Payment.
-                
+
                 // For now, I'll return Ok to simulate success so the UI updates.
                 // If the user wants real logic, they'd likely provide the manager method.
                 // I will add a TODO comment.
-                
+
                 // _logger.LogInformation("Applying promo {PromoId} to payment {PaymentId}", promocodeId, id);
-                
-                return Ok(new { message = "Promocode applied successfully (Simulation)" });
-            }
-            catch (Exception ex)
-            {
-                return BadRequest(ex.Message);
+   
+                    return Ok(new { message = "Promocode applied successfully (Simulation)" });
+                }
+                catch (Exception ex)
+                {
+                    return BadRequest(ex.Message);
+                }
             }
         }
     }
-}

--- a/RentACar.Web/Controllers/StripeController.cs
+++ b/RentACar.Web/Controllers/StripeController.cs
@@ -95,14 +95,14 @@ namespace RentACar.Web.Controllers
         [AllowAnonymous]
         public IActionResult Success()
         {
-            return RedirectToAction("Index", "Home");
+            return View("~/Views/Stripe/Success.cshtml");
         }
 
         [HttpGet("Cancel")]
         [AllowAnonymous]
         public IActionResult Cancel()
         {
-            return RedirectToAction("Index", "Home");
+            return View("~/Views/Stripe/Cancel.cshtml");
         }
     }
 }

--- a/RentACar.Web/Views/Bookings/MyBookings.cshtml
+++ b/RentACar.Web/Views/Bookings/MyBookings.cshtml
@@ -12,7 +12,7 @@
                     <tr>
                         <th>Booking ID</th>
                         <th>Car</th>
-                        <th>Payment</th>
+                        <th>Payment Status</th>
                         <th>Start</th>
                         <th>End</th>
                         <th>Price</th>
@@ -24,25 +24,131 @@
         </div>
     </div>
 </div>
+<div class="modal fade" id="payModal" tabindex="-1" aria-labelledby="payModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content bg-dark text-light">
+            <div class="modal-header border-secondary">
+                <h5 class="modal-title" id="payModalLabel">Pay for Booking</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Total Amount</label>
+                    <div id="paymentAmount" class="fw-bold"></div>
+                </div>
+                <div class="mb-3">
+                    <label for="paymentMethodSelect" class="form-label">Payment Method</label>
+                    <select id="paymentMethodSelect" class="form-select"></select>
+                </div>
+                <div id="paymentError" class="text-danger small d-none"></div>
+            </div>
+            <div class="modal-footer border-secondary">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="confirmPayBtn">Pay Now</button>
+            </div>
+        </div>
+    </div>
+</div>
 @section Scripts{
     <script>
+        let selectedBookingId = null;
+        let selectedAmount = null;
+        let paymentMethods = [];
+        let payModal;
+
+        async function loadPaymentMethods(){
+            const res = await fetch('/api/PaymentMethod/active');
+            if(!res.ok){
+                return;
+            }
+            paymentMethods = await res.json();
+            const select = document.getElementById('paymentMethodSelect');
+            select.innerHTML='';
+            paymentMethods.forEach(method => {
+                const option = document.createElement('option');
+                option.value = method.id;
+                option.textContent = method.paymentMethodName;
+                select.appendChild(option);
+            });
+        }
+
         async function loadBookings(){
             const res = await fetch('/api/Bookings');
             const data = await res.json();
             const tbody = document.getElementById('bookingRows');
             tbody.innerHTML='';
             data.forEach(b=>{
+                const paymentStatus = b.paymentStatus ?? 'unpaid';
+                const statusLabel = paymentStatus === 'done'
+                    ? 'Paid'
+                    : paymentStatus === 'pending'
+                        ? 'Pending'
+                        : 'Unpaid';
+                const payDisabled = paymentStatus === 'pending';
+                const showPayButton = paymentStatus !== 'done';
                 const tr=document.createElement('tr');
                 tr.innerHTML=`<td>${b.bookingId}</td>`+
                               `<td>${b.carName ?? ''} (${b.plateNumber ?? ''})</td>`+
-                              `<td>${b.paymentId ?? ''}</td>`+
+                              `<td>${statusLabel}</td>`+
                               `<td>${b.startdate}</td>`+
                               `<td>${b.enddate}</td>`+
                               `<td>${b.totalPrice}</td>`+
-                              `<td><a class='btn btn-primary btn-sm' href='/Bookings/Ticket/${b.bookingId}' target='_blank'>Ticket</a></td>`;
+                              `<td>
+                                    ${showPayButton ? `<button class='btn btn-primary btn-sm me-2 pay-btn' data-booking-id='${b.bookingId}' data-amount='${b.totalPrice}' ${payDisabled ? 'disabled' : ''}>Pay</button>` : ''}
+                                    <a class='btn btn-secondary btn-sm' href='/Bookings/Ticket/${b.bookingId}' target='_blank'>Ticket</a>
+                                </td>`;
                 tbody.appendChild(tr);
             });
+
+            document.querySelectorAll('.pay-btn').forEach(button => {
+                button.addEventListener('click', () => {
+                    selectedBookingId = Number(button.dataset.bookingId);
+                    selectedAmount = Number(button.dataset.amount);
+                    document.getElementById('paymentAmount').textContent = selectedAmount.toFixed(2);
+                    document.getElementById('paymentError').classList.add('d-none');
+                    payModal.show();
+                });
+            });
         }
+
+        async function submitPayment(){
+            const paymentMethodId = Number(document.getElementById('paymentMethodSelect').value);
+            if(!selectedBookingId || !paymentMethodId){
+                return;
+            }
+
+            const res = await fetch('/api/Bookings/Pay', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    bookingId: selectedBookingId,
+                    amount: selectedAmount,
+                    paymentMethodId: paymentMethodId
+                })
+            });
+
+            if(!res.ok){
+                const errorEl = document.getElementById('paymentError');
+                errorEl.textContent = 'Unable to process payment. Please try again.';
+                errorEl.classList.remove('d-none');
+                return;
+            }
+
+            const result = await res.json();
+            if(result.requiresRedirect && result.redirectUrl){
+                window.location.href = result.redirectUrl;
+                return;
+            }
+
+            payModal.hide();
+            await loadBookings();
+        }
+
         document.addEventListener('DOMContentLoaded', loadBookings);
+        document.addEventListener('DOMContentLoaded', async () => {
+            payModal = new bootstrap.Modal(document.getElementById('payModal'));
+            await loadPaymentMethods();
+            document.getElementById('confirmPayBtn').addEventListener('click', submitPayment);
+        });
     </script>
 }

--- a/RentACar.Web/Views/Bookings/MyBookings.cshtml
+++ b/RentACar.Web/Views/Bookings/MyBookings.cshtml
@@ -29,7 +29,8 @@
         <div class="modal-content bg-dark text-light">
             <div class="modal-header border-secondary">
                 <h5 class="modal-title" id="payModalLabel">Pay for Booking</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+                    aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <div class="mb-3">
@@ -56,14 +57,14 @@
         let paymentMethods = [];
         let payModal;
 
-        async function loadPaymentMethods(){
+        async function loadPaymentMethods() {
             const res = await fetch('/api/PaymentMethod/active');
-            if(!res.ok){
-                return;
-            }
+            if (!res.ok) return;
+
             paymentMethods = await res.json();
             const select = document.getElementById('paymentMethodSelect');
-            select.innerHTML='';
+            select.innerHTML = '';
+
             paymentMethods.forEach(method => {
                 const option = document.createElement('option');
                 option.value = method.id;
@@ -72,31 +73,53 @@
             });
         }
 
-        async function loadBookings(){
+        async function loadBookings() {
             const res = await fetch('/api/Bookings');
             const data = await res.json();
             const tbody = document.getElementById('bookingRows');
-            tbody.innerHTML='';
-            data.forEach(b=>{
-                const paymentStatus = b.paymentStatus ?? 'unpaid';
-                const statusLabel = paymentStatus === 'done'
-                    ? 'Paid'
-                    : paymentStatus === 'pending'
-                        ? 'Pending'
-                        : 'Unpaid';
+            tbody.innerHTML = '';
+
+            data.forEach(b => {
+                const paymentStatus = (b.paymentStatus ?? 'unpaid')
+                    .toString()
+                    .trim()
+                    .toLowerCase();
+
+                const statusLabel =
+                    paymentStatus === 'done' || paymentStatus === 'paid'
+                        ? 'Paid'
+                        : paymentStatus === 'pending'
+                            ? 'Pending'
+                            : 'Unpaid';
+
                 const payDisabled = paymentStatus === 'pending';
-                const showPayButton = paymentStatus !== 'done';
-                const tr=document.createElement('tr');
-                tr.innerHTML=`<td>${b.bookingId}</td>`+
-                              `<td>${b.carName ?? ''} (${b.plateNumber ?? ''})</td>`+
-                              `<td>${statusLabel}</td>`+
-                              `<td>${b.startdate}</td>`+
-                              `<td>${b.enddate}</td>`+
-                              `<td>${b.totalPrice}</td>`+
-                              `<td>
-                                    ${showPayButton ? `<button class='btn btn-primary btn-sm me-2 pay-btn' data-booking-id='${b.bookingId}' data-amount='${b.totalPrice}' ${payDisabled ? 'disabled' : ''}>Pay</button>` : ''}
-                                    <a class='btn btn-secondary btn-sm' href='/Bookings/Ticket/${b.bookingId}' target='_blank'>Ticket</a>
-                                </td>`;
+                const showPayButton = paymentStatus !== 'done' && paymentStatus !== 'paid';
+
+                const tr = document.createElement('tr');
+                tr.innerHTML =
+                    `<td>${b.bookingId}</td>` +
+                    `<td>${b.carName ?? ''} (${b.plateNumber ?? ''})</td>` +
+                    `<td>${b.paymentId ?? ''}</td>` +
+                    `<td>${statusLabel}</td>` +
+                    `<td>${b.startdate}</td>` +
+                    `<td>${b.enddate}</td>` +
+                    `<td>${Number(b.totalPrice ?? 0).toFixed(2)}</td>` +
+                    `<td>
+                                ${showPayButton ? `
+                                    <button class="btn btn-primary btn-sm me-2 pay-btn"
+                                            data-booking-id="${b.bookingId}"
+                                            data-amount="${Number(b.totalPrice ?? 0)}"
+                                            ${payDisabled ? 'disabled' : ''}>
+                                        Pay
+                                    </button>
+                                ` : ''}
+                                <a class="btn btn-secondary btn-sm"
+                                   href="/Bookings/Ticket/${b.bookingId}"
+                                   target="_blank">
+                                    Ticket
+                                </a>
+                            </td>`;
+
                 tbody.appendChild(tr);
             });
 
@@ -104,18 +127,21 @@
                 button.addEventListener('click', () => {
                     selectedBookingId = Number(button.dataset.bookingId);
                     selectedAmount = Number(button.dataset.amount);
-                    document.getElementById('paymentAmount').textContent = selectedAmount.toFixed(2);
+
+                    document.getElementById('paymentAmount').textContent =
+                        selectedAmount.toFixed(2);
+
                     document.getElementById('paymentError').classList.add('d-none');
                     payModal.show();
                 });
             });
         }
 
-        async function submitPayment(){
-            const paymentMethodId = Number(document.getElementById('paymentMethodSelect').value);
-            if(!selectedBookingId || !paymentMethodId){
-                return;
-            }
+        async function submitPayment() {
+            const paymentMethodId =
+                Number(document.getElementById('paymentMethodSelect').value);
+
+            if (!selectedBookingId || !paymentMethodId) return;
 
             const res = await fetch('/api/Bookings/Pay', {
                 method: 'POST',
@@ -127,7 +153,7 @@
                 })
             });
 
-            if(!res.ok){
+            if (!res.ok) {
                 const errorEl = document.getElementById('paymentError');
                 errorEl.textContent = 'Unable to process payment. Please try again.';
                 errorEl.classList.remove('d-none');
@@ -135,7 +161,8 @@
             }
 
             const result = await res.json();
-            if(result.requiresRedirect && result.redirectUrl){
+
+            if (result.requiresRedirect && result.redirectUrl) {
                 window.location.href = result.redirectUrl;
                 return;
             }
@@ -144,11 +171,12 @@
             await loadBookings();
         }
 
-        document.addEventListener('DOMContentLoaded', loadBookings);
         document.addEventListener('DOMContentLoaded', async () => {
             payModal = new bootstrap.Modal(document.getElementById('payModal'));
             await loadPaymentMethods();
-            document.getElementById('confirmPayBtn').addEventListener('click', submitPayment);
+            await loadBookings();
+            document.getElementById('confirmPayBtn')
+                .addEventListener('click', submitPayment);
         });
     </script>
 }

--- a/RentACar.Web/Views/Stripe/Cancel.cshtml
+++ b/RentACar.Web/Views/Stripe/Cancel.cshtml
@@ -1,0 +1,14 @@
+@{
+    ViewData["Title"] = "Payment Cancelled";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container py-5">
+    <div class="card bg-dark text-light border-secondary shadow-sm">
+        <div class="card-body text-center">
+            <h2 class="text-warning mb-3">Payment Cancelled</h2>
+            <p class="mb-4">Your payment was cancelled. You can try again from your bookings.</p>
+            <a class="btn btn-primary" href="/Bookings/MyBookings">Back to My Bookings</a>
+        </div>
+    </div>
+</div>

--- a/RentACar.Web/Views/Stripe/Success.cshtml
+++ b/RentACar.Web/Views/Stripe/Success.cshtml
@@ -1,0 +1,14 @@
+@{
+    ViewData["Title"] = "Payment Success";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container py-5">
+    <div class="card bg-dark text-light border-secondary shadow-sm">
+        <div class="card-body text-center">
+            <h2 class="text-success mb-3">Payment Successful</h2>
+            <p class="mb-4">Thank you! Your payment has been confirmed.</p>
+            <a class="btn btn-primary" href="/Bookings/MyBookings">Back to My Bookings</a>
+        </div>
+    </div>
+</div>

--- a/RentACar.Web/appsettings.json
+++ b/RentACar.Web/appsettings.json
@@ -9,13 +9,26 @@
     }
   },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.File"
+    ],
     "MinimumLevel": "Information",
     "WriteTo": [
-      { "Name": "Console" },
-      { "Name": "File", "Args": { "path": "Logs/log-.txt", "rollingInterval": "Day" } }
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "Logs/log-.txt",
+          "rollingInterval": "Day"
+        }
+      }
     ],
-    "Enrich": [ "FromLogContext" ],
+    "Enrich": [
+      "FromLogContext"
+    ],
     "Properties": {
       "Application": "RentACar.Web"
     }


### PR DESCRIPTION
### Motivation
- Enable customers to pay for their own bookings using Stripe Checkout and to see payment status on the My Bookings page.
- Ensure card payments create a pending `Payment` and redirect the customer to Stripe, while non-card methods are marked done immediately.
- Make webhook processing and customer payment initiation idempotent to avoid duplicate payments and race conditions.
- Provide simple success and cancel pages after Stripe Checkout completes.

### Description
- Added idempotent customer payment flow in `PaymentManager.MakePaymentByCustomerAsync` that returns existing payment if one exists and creates a Stripe Checkout session for credit card methods. 
- Made `MarkPaymentPaidAsync` idempotent by returning early when a payment is already marked `done` and updating provider IDs when webhook arrives. 
- Exposed a new customer endpoint `POST api/Bookings/Pay` in `BookingsController` and included `paymentStatus` in the bookings `GET` response. 
- Updated `Views/Bookings/MyBookings.cshtml` to display payment status, load active methods from `GET /api/PaymentMethod/active`, show a payment modal, call `POST /api/Bookings/Pay`, and redirect to Stripe when `RequiresRedirect` is returned; and added `Views/Stripe/Success.cshtml` and `Views/Stripe/Cancel.cshtml` with controller wiring to render them.

### Testing
- Attempted to run the web project with `dotnet run --project RentACar.Web --urls http://0.0.0.0:5000`, but the command could not be executed because `dotnet` is not installed in the environment, so runtime verification was not performed. 
- No automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663a90d67483208bdce6a974119063)