### PR TITLE
Create Unpaid Payments + Stripe redirect on booking, and normalize booking/payment statuses

### DIFF
--- a/RentACar.Application/DTOs/BookingDto.cs
+++ b/RentACar.Application/DTOs/BookingDto.cs
@@ -31,7 +31,7 @@ namespace RentACar.Application.DTOs
         public decimal TotalPrice { get; set; }
 
         [StringLength(50)]
-        public string BookingStatus { get; set; } = "pending";
+        public string BookingStatus { get; set; } = "Pending";
 
         [Range(0.01, double.MaxValue, ErrorMessage = "Subtotal must be greater than 0.")]
         public decimal? Subtotal { get; set; }
@@ -73,6 +73,13 @@ namespace RentACar.Application.DTOs
         public DateOnly Startdate { get; set; }
         public DateOnly Enddate { get; set; }
         public decimal TotalPrice { get; set; } // still validated
-        public string BookingStatus { get; set; } = "pending";
+        public string BookingStatus { get; set; } = "Pending";
+    }
+
+    public class BookingCreationResultDto
+    {
+        public BookingDto Booking { get; set; } = new();
+        public string? RedirectUrl { get; set; }
+        public int? PaymentId { get; set; }
     }
 }

--- a/RentACar.Application/Managers/BookingManager.cs
+++ b/RentACar.Application/Managers/BookingManager.cs
@@ -55,7 +55,7 @@ namespace RentACar.Application.Managers
             _auditLogManager = auditLogManager;
         }
 
-        public async Task<BookingDto?> MakeBookingAsync(MakeBookingRequestDto requestDto, string loggedInUserId)
+        public async Task<BookingCreationResultDto?> MakeBookingAsync(MakeBookingRequestDto requestDto, string loggedInUserId)
         {
             _logger.LogInformation("=== MakeBookingAsync START ===");
             _logger.LogInformation("LoggedInUserId: {UserId}", loggedInUserId);
@@ -181,14 +181,17 @@ namespace RentACar.Application.Managers
             // Save booking first to generate BookingId
             var addedBooking = await _bookingRepository.AddAsync(booking);
 
+            var payableAmount = CalculatePayableAmount(totalPrice, paymentMethod.PaymentMethodName);
+
             // 🔹 Create payment linked to the newly created booking
             var payment = new Payment
             {
                 BookingId = addedBooking.BookingId,
-                Amount = totalPrice,
+                Amount = payableAmount,
                 PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
                 PaymentMethod = paymentMethod.PaymentMethodName,
-                Status = "done",
+                Status = "Unpaid",
+                PaymentProvider = "Stripe",
                 CreditcardId = paymentMethod.PaymentMethodName.Equals("creditcard", StringComparison.OrdinalIgnoreCase)
                     ? requestDto.CreditcardId
                     : null
@@ -200,7 +203,18 @@ namespace RentACar.Application.Managers
             
             await _auditLogManager.LogAsync("Create", "Booking", addedBooking.BookingId.ToString(), $"Created new booking for Car {addedBooking.CarId}");
             
-            return _mapper.Map<BookingDto>(addedBooking);
+            var session = await _paymentManager.CreateCheckoutSessionForPaymentAsync(addedPayment);
+            if (string.IsNullOrWhiteSpace(session.CheckoutUrl))
+            {
+                _logger.LogWarning("Stripe checkout session missing URL for booking {BookingId}", addedBooking.BookingId);
+            }
+
+            return new BookingCreationResultDto
+            {
+                Booking = _mapper.Map<BookingDto>(addedBooking),
+                RedirectUrl = session.CheckoutUrl,
+                PaymentId = addedPayment.PaymentId
+            };
         }
 
 
@@ -216,8 +230,23 @@ namespace RentACar.Application.Managers
                 return true;
             }
 
-            return !status.Equals("cancelled", StringComparison.OrdinalIgnoreCase)
+            return !status.Equals("returned", StringComparison.OrdinalIgnoreCase)
                 && !status.Equals("rejected", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static decimal CalculatePayableAmount(decimal totalPrice, string? paymentMethodName)
+        {
+            if (string.IsNullOrWhiteSpace(paymentMethodName))
+            {
+                return totalPrice;
+            }
+
+            if (paymentMethodName.Equals("cash", StringComparison.OrdinalIgnoreCase))
+            {
+                return Math.Round(totalPrice * 0.30m, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return totalPrice;
         }
 
 

--- a/RentACar.Application/Managers/PaymentManager.cs
+++ b/RentACar.Application/Managers/PaymentManager.cs
@@ -69,7 +69,7 @@ namespace RentACar.Application.Managers
                     .First();
 
                 // ✅ If already paid, don't redirect
-                if (string.Equals(latestPayment.Status, "done", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(latestPayment.Status, "paid", StringComparison.OrdinalIgnoreCase))
                 {
                     var paidDto = _mapper.Map<PaymentDto>(latestPayment);
 
@@ -84,7 +84,7 @@ namespace RentACar.Application.Managers
                     };
                 }
 
-                // ✅ If NOT paid yet (unpaid/pending), continue to create Stripe session (redirect)
+                // ✅ If NOT paid yet (unpaid), continue to create Stripe session (redirect)
                 // so DO NOT return here
             }
 
@@ -101,7 +101,7 @@ namespace RentACar.Application.Managers
                     Amount = paymentDto.Amount,
                     PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
                     PaymentMethod = paymentMethod.PaymentMethodName,
-                    Status = "pending",
+                    Status = "Unpaid",
                     PaymentProvider = "Stripe"
                 };
 
@@ -135,7 +135,7 @@ namespace RentACar.Application.Managers
                     Amount = paymentDto.Amount,
                     PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
                     PaymentMethod = paymentMethod.PaymentMethodName,
-                    Status = "done"
+                    Status = "Paid"
                 };
                 await _paymentRepository.AddAsync(payment);
                 await _auditLogManager.LogAsync("Create", "Payment", payment.PaymentId.ToString(), $"Customer payment of {payment.Amount:C} via {payment.PaymentMethod}");
@@ -176,7 +176,7 @@ namespace RentACar.Application.Managers
                     PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
                     CreditcardId = paymentDto.CreditcardId,
                     PaymentMethod = paymentMethod.PaymentMethodName,
-                    Status = "done"
+                    Status = "Paid"
                 };
 
                 await _paymentRepository.AddAsync(payment);
@@ -209,7 +209,7 @@ namespace RentACar.Application.Managers
                     Amount = paymentDto.Amount,
                     PaymentDate = DateOnly.FromDateTime(DateTime.UtcNow),
                     PaymentMethod = paymentMethod.PaymentMethodName,
-                    Status = "done"
+                    Status = "Paid"
                 };
 
                 await _paymentRepository.AddAsync(payment);
@@ -233,13 +233,13 @@ namespace RentACar.Application.Managers
                 return false;
             }
 
-            if (string.Equals(payment.Status, "done", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(payment.Status, "paid", StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Stripe webhook received for already completed payment {PaymentId}", paymentId);
                 return true;
             }
 
-            payment.Status = "done";
+            payment.Status = "Paid";
             payment.PaymentProvider = "Stripe";
             if (!string.IsNullOrWhiteSpace(paymentIntentId))
             {
@@ -252,6 +252,11 @@ namespace RentACar.Application.Managers
             }
 
             await _paymentRepository.UpdateAsync(payment);
+            var booking = await _bookingRepository.GetByIdAsync(payment.BookingId);
+            if (booking != null)
+            {
+                await UpdateBookingStatusForPaymentAsync(booking, payment.Status);
+            }
             return true;
         }
 
@@ -360,7 +365,7 @@ namespace RentACar.Application.Managers
                 PaymentDate = dto.PaymentDate,
                 CreditcardId = dto.CreditcardId,
                 PaymentMethod = paymentMethod.PaymentMethodName,
-                Status = dto.Status,
+                Status = NormalizePaymentStatus(dto.Status),
                 PaymentProvider = dto.PaymentProvider,
                 PaymentProviderSessionId = dto.PaymentProviderSessionId,
                 PaymentProviderPaymentIntentId = dto.PaymentProviderPaymentIntentId
@@ -434,7 +439,7 @@ namespace RentACar.Application.Managers
             existing.PaymentDate = dto.PaymentDate;
             existing.CreditcardId = dto.CreditcardId;
             existing.PaymentMethod = paymentMethod.PaymentMethodName;
-            existing.Status = dto.Status;
+            existing.Status = NormalizePaymentStatus(dto.Status);
             existing.PaymentProvider = dto.PaymentProvider;
             existing.PaymentProviderSessionId = dto.PaymentProviderSessionId;
             existing.PaymentProviderPaymentIntentId = dto.PaymentProviderPaymentIntentId;
@@ -533,18 +538,88 @@ namespace RentACar.Application.Managers
                 return;
             }
 
-            if (paymentStatus.Equals("rejected", StringComparison.OrdinalIgnoreCase) ||
-                paymentStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase))
+            if (paymentStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase) ||
+                paymentStatus.Equals("unpaid", StringComparison.OrdinalIgnoreCase))
             {
-                var targetStatus = paymentStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase)
-                    ? "cancelled"
-                    : "rejected";
+                return;
+            }
+
+            if (paymentStatus.Equals("paid", StringComparison.OrdinalIgnoreCase))
+            {
+                const string targetStatus = "Booked";
                 if (!string.Equals(booking.BookingStatus, targetStatus, StringComparison.OrdinalIgnoreCase))
                 {
                     booking.BookingStatus = targetStatus;
                     await _bookingRepository.UpdateAsync(booking);
                 }
             }
+        }
+
+        public async Task<bool> MarkPaymentCancelledAsync(int paymentId)
+        {
+            var payment = await _paymentRepository.GetByIdAsync(paymentId);
+            if (payment == null)
+            {
+                _logger.LogWarning("Stripe cancel received for missing payment {PaymentId}", paymentId);
+                return false;
+            }
+
+            if (string.Equals(payment.Status, "cancelled", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            payment.Status = "Cancelled";
+            await _paymentRepository.UpdateAsync(payment);
+            return true;
+        }
+
+        public async Task<StripeCheckoutSessionDto> CreateCheckoutSessionForPaymentAsync(Payment payment)
+        {
+            var session = await CreateStripeCheckoutSessionAsync(payment);
+
+            if (!string.IsNullOrWhiteSpace(session.SessionId))
+            {
+                payment.PaymentProviderSessionId = session.SessionId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(session.PaymentIntentId))
+            {
+                payment.PaymentProviderPaymentIntentId = session.PaymentIntentId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(session.SessionId) || !string.IsNullOrWhiteSpace(session.PaymentIntentId))
+            {
+                payment.PaymentProvider = "Stripe";
+                await _paymentRepository.UpdateAsync(payment);
+            }
+
+            return session;
+        }
+
+        private static string? NormalizePaymentStatus(string? status)
+        {
+            if (string.IsNullOrWhiteSpace(status))
+            {
+                return status;
+            }
+
+            if (status.Equals("done", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Paid";
+            }
+
+            if (status.Equals("pending", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Unpaid";
+            }
+
+            if (status.Equals("rejected", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Cancelled";
+            }
+
+            return status;
         }
 
         private async Task<StripeCheckoutSessionDto> CreateStripeCheckoutSessionAsync(Payment payment)

--- a/RentACar.Infrastructure/Migrations/20250312000000_NormalizeBookingAndPaymentStatuses.sql
+++ b/RentACar.Infrastructure/Migrations/20250312000000_NormalizeBookingAndPaymentStatuses.sql
@@ -1,0 +1,23 @@
+-- Normalize booking statuses to: Booked, Pending, Rejected, Returned
+UPDATE Bookings
+SET bookingStatus = CASE
+    WHEN bookingStatus IS NULL THEN bookingStatus
+    WHEN LOWER(bookingStatus) = 'accepted' THEN 'Booked'
+    WHEN LOWER(bookingStatus) = 'booked' THEN 'Booked'
+    WHEN LOWER(bookingStatus) = 'pending' THEN 'Pending'
+    WHEN LOWER(bookingStatus) = 'returned' THEN 'Returned'
+    WHEN LOWER(bookingStatus) = 'rejected' THEN 'Rejected'
+    WHEN LOWER(bookingStatus) = 'cancelled' THEN 'Rejected'
+    WHEN LOWER(bookingStatus) = 'canceled' THEN 'Rejected'
+    ELSE bookingStatus
+END;
+
+-- Normalize payment statuses to: Paid, Unpaid, Cancelled
+UPDATE Payments
+SET status = CASE
+    WHEN status IS NULL THEN status
+    WHEN LOWER(status) IN ('done', 'paid') THEN 'Paid'
+    WHEN LOWER(status) IN ('pending', 'unpaid') THEN 'Unpaid'
+    WHEN LOWER(status) IN ('cancelled', 'canceled', 'rejected') THEN 'Cancelled'
+    ELSE status
+END;

--- a/RentACar.Web/Controllers/BookingController.cs
+++ b/RentACar.Web/Controllers/BookingController.cs
@@ -108,7 +108,7 @@ namespace RentACar.Web.Controllers
             if (booking == null) return NotFound();
 
             var editDto = _mapper.Map<BookingEditDto>(booking);
-            editDto.BookingStatus = "Accepted"; // Setting status to Accepted
+            editDto.BookingStatus = "Booked"; // Setting status to Booked
             
             await _bookingManager.UpdateBookingAsync(editDto);
 
@@ -267,7 +267,7 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<BookingDto>> Create([FromBody] MakeBookingRequestDto dto)
+        public async Task<ActionResult<BookingCreationResultDto>> Create([FromBody] MakeBookingRequestDto dto)
         {
             if (!User.Identity?.IsAuthenticated ?? true)
                 return Unauthorized();
@@ -292,7 +292,7 @@ namespace RentACar.Web.Controllers
                     return BadRequest("Booking could not be created. Please check availability, customer status, or payment info.");
                 }
 
-                return CreatedAtAction(nameof(Get), new { id = created.BookingId }, created);
+                return CreatedAtAction(nameof(Get), new { id = created.Booking.BookingId }, created);
             }
             catch (Exception ex)
             {

--- a/RentACar.Web/Controllers/DashboardController.cs
+++ b/RentACar.Web/Controllers/DashboardController.cs
@@ -242,7 +242,7 @@ namespace RentACar.Web.Controllers
                     CustomerImage = $"https://ui-avatars.com/api/?name={(b.Customer != null ? b.Customer.Name : "User")}&background=random", // Placeholder
                     CarModel = b.Car != null ? b.Car.ModelName : "Unknown Car",
                     DateRange = $"{b.Startdate:MMM dd} - {b.Enddate:MMM dd}",
-                    Status = "Pending Review",
+                    Status = "Pending",
                     StatusColorClass = "bg-yellow-500/10 text-yellow-500"
                 })
                 .ToListAsync();
@@ -333,8 +333,9 @@ namespace RentACar.Web.Controllers
                         DateRange = $"{b.Startdate:MMM dd} - {b.Enddate:MMM dd}",
                         TotalPrice = b.TotalPrice,
                         Status = b.BookingStatus,
-                        StatusColorClass = b.BookingStatus == "Accepted" ? "text-green-500 bg-green-500/10" :
+                        StatusColorClass = b.BookingStatus == "Booked" ? "text-green-500 bg-green-500/10" :
                                            b.BookingStatus == "Pending" ? "text-yellow-500 bg-yellow-500/10" :
+                                           b.BookingStatus == "Returned" ? "text-blue-500 bg-blue-500/10" :
                                            "text-red-500 bg-red-500/10"
                     };
                 })

--- a/RentACar.Web/Controllers/StripeController.cs
+++ b/RentACar.Web/Controllers/StripeController.cs
@@ -100,8 +100,13 @@ namespace RentACar.Web.Controllers
 
         [HttpGet("Cancel")]
         [AllowAnonymous]
-        public IActionResult Cancel()
+        public async Task<IActionResult> Cancel(int? paymentId = null)
         {
+            if (paymentId.HasValue)
+            {
+                await _paymentManager.MarkPaymentCancelledAsync(paymentId.Value);
+            }
+
             return View("~/Views/Stripe/Cancel.cshtml");
         }
     }

--- a/RentACar.Web/Views/Bookings/MyBookings.cshtml
+++ b/RentACar.Web/Views/Bookings/MyBookings.cshtml
@@ -86,14 +86,14 @@
                     .toLowerCase();
 
                 const statusLabel =
-                    paymentStatus === 'done' || paymentStatus === 'paid'
+                    paymentStatus === 'paid'
                         ? 'Paid'
-                        : paymentStatus === 'pending'
-                            ? 'Pending'
+                        : paymentStatus === 'cancelled'
+                            ? 'Cancelled'
                             : 'Unpaid';
 
-                const payDisabled = paymentStatus === 'pending';
-                const showPayButton = paymentStatus !== 'done' && paymentStatus !== 'paid';
+                const payDisabled = paymentStatus === 'unpaid';
+                const showPayButton = paymentStatus !== 'paid';
 
                 const tr = document.createElement('tr');
                 tr.innerHTML =

--- a/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
@@ -117,10 +117,15 @@
                     body: JSON.stringify(data)
                 });
 
-                const redirectUrl = '@(isCustomer ? "/Bookings/MyBookings" : "/Booking")';
                 if (resp.ok) {
+                    const result = await resp.json();
+                    if (result.redirectUrl) {
+                        window.location.href = result.redirectUrl;
+                        return;
+                    }
                     showPopup('Booking created successfully.', 'success');
-                    setTimeout(() => { window.location.href = redirectUrl; }, 1000);
+                    const fallbackUrl = '@(isCustomer ? "/Bookings/MyBookings" : "/Booking")';
+                    setTimeout(() => { window.location.href = fallbackUrl; }, 1000);
                 } else {
                     const errorText = await resp.text();
                     showPopup(`Error creating booking:\n${errorText}`, 'error');

--- a/RentACar.Web/Views/ControlPanel/Booking/Edit.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Booking/Edit.cshtml
@@ -43,12 +43,10 @@
             <div class="mb-3">
                 <label class="form-label">Booking Status</label>
                 <select asp-for="BookingStatus" class="form-select">
-                    <option value="pending" selected="@(Model.BookingStatus == "pending")">Pending</option>
-                    <option value="accepted" selected="@(Model.BookingStatus == "accepted")">Accepted</option>
-                    <option value="booked" selected="@(Model.BookingStatus == "booked")">Booked</option>
-                    <option value="returned" selected="@(Model.BookingStatus == "returned")">Returned</option>
-                    <option value="rejected" selected="@(Model.BookingStatus == "rejected")">Rejected</option>
-                    <option value="cancelled" selected="@(Model.BookingStatus == "cancelled")">Cancelled</option>
+                    <option value="Pending" selected="@(Model.BookingStatus == "Pending")">Pending</option>
+                    <option value="Booked" selected="@(Model.BookingStatus == "Booked")">Booked</option>
+                    <option value="Returned" selected="@(Model.BookingStatus == "Returned")">Returned</option>
+                    <option value="Rejected" selected="@(Model.BookingStatus == "Rejected")">Rejected</option>
                 </select>
 
             </div>

--- a/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Add.cshtml
@@ -62,9 +62,9 @@
                     <label class="form-label text-white">Status</label>
                     <select name="Status" class="form-select">
                         <option value="" selected>Select status</option>
-                        <option value="pending">Pending</option>
-                        <option value="done">Done</option>
-                        <option value="rejected">Rejected</option>
+                        <option value="Unpaid">Unpaid</option>
+                        <option value="Paid">Paid</option>
+                        <option value="Cancelled">Cancelled</option>
                     </select>
                 </div>
                 <button type="submit" class="login-btn w-100">Save</button>

--- a/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Payment/Edit.cshtml
@@ -54,9 +54,9 @@
                 <div class="input mb-4">
                     <label class="form-label text-white">Status</label>
                     <select name="Status" class="form-select">
-                        <option value="pending" selected="@(statusValue == "pending" ? "selected" : null)">Pending</option>
-                        <option value="done" selected="@(statusValue == "done" ? "selected" : null)">Done</option>
-                        <option value="rejected" selected="@(statusValue == "rejected" ? "selected" : null)">Rejected</option>
+                        <option value="Unpaid" selected="@(statusValue == "unpaid" ? "selected" : null)">Unpaid</option>
+                        <option value="Paid" selected="@(statusValue == "paid" ? "selected" : null)">Paid</option>
+                        <option value="Cancelled" selected="@(statusValue == "cancelled" ? "selected" : null)">Cancelled</option>
 
                     </select>
                 </div>


### PR DESCRIPTION
### Motivation
- Prevent new bookings from being stored as already paid and ensure the payment flow always routes through Stripe for card payments. 
- Enforce business rules for cash vs credit card payable amounts when creating a booking. 
- Reduce and normalize enums used in the app to a consistent set for booking and payment statuses for UI, DTOs, and backend logic. 
- Provide a DB migration script to map existing legacy status values to the new canonical sets.

### Description
- Booking creation now: computes payable amount (30% for `cash`, 100% for `creditcard`), creates a `Payment` with `Status = "Unpaid"` and `PaymentProvider = "Stripe"`, creates a Stripe checkout session and returns a `BookingCreationResultDto` containing `RedirectUrl` and `PaymentId` so the UI redirects immediately to Stripe; implemented in `BookingManager.MakeBookingAsync`, `PaymentManager.CreateCheckoutSessionForPaymentAsync`, and `BookingController.Create`. 
- Payment flow & statuses normalized to `Paid`, `Unpaid`, `Cancelled` and booking statuses to `Booked`, `Pending`, `Rejected`, `Returned`, with helpers to normalize incoming status strings and to update booking status on Stripe success; implemented in `PaymentManager` (including `NormalizePaymentStatus`, `MarkPaymentPaidAsync`, `MarkPaymentCancelledAsync`, and status handling). 
- UI surfaces updated so dropdowns and displays use the new canonical status values and the Add Booking page and JS will redirect to Stripe immediately when a `RedirectUrl` is returned; changes in `Views/ControlPanel/*` and `Views/Bookings/MyBookings.cshtml`. 
- Added a SQL migration script `RentACar.Infrastructure/Migrations/20250312000000_NormalizeBookingAndPaymentStatuses.sql` to map legacy `bookingStatus` and `Payments.status` values to the new normalized sets.

### Testing
- Attempted to run the web application with `dotnet run --project RentACar.Web`, but the runtime was not available in the environment so end-to-end execution and integration tests were not executed. 
- Project compiles were not validated in this environment due to missing `dotnet`, so no automated tests succeeded or failed here. 
- Per-change static verification: key code paths and view templates were updated to reference the new status strings and to wire the Stripe redirect flow; manual code inspection performed. 
- The provided SQL migration script was added to the repo for DB compatibility and should be executed in database staging before deployment to migrate existing rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665a93ec548320b41921193c759b89)