### PR TITLE
Implement Driver role, availability, assignment and real-time tracking (SignalR)

### DIFF
--- a/RentACar.Application/DTOs/BookingDto.cs
+++ b/RentACar.Application/DTOs/BookingDto.cs
@@ -26,6 +26,18 @@ namespace RentACar.Application.DTOs
 
         public int? PromocodeId { get; set; }
 
+        public bool HasDriver { get; set; }
+
+        public int? DriverId { get; set; }
+
+        public string? PickupAddress { get; set; }
+
+        public decimal? PickupLat { get; set; }
+
+        public decimal? PickupLng { get; set; }
+
+        public decimal? DriverFee { get; set; }
+
         [Required]
         [Range(0.01, double.MaxValue, ErrorMessage = "Total price must be greater than 0.")]
         public decimal TotalPrice { get; set; }
@@ -58,6 +70,14 @@ namespace RentACar.Application.DTOs
         public string? Promocode { get; set; } // To apply promocode by string
         public int PaymentMethodId { get; set; } // "Cash" or "CreditCard"
         public int? CreditcardId { get; set; } // If paying by credit card
+
+        public bool HasDriver { get; set; }
+
+        public string? PickupAddress { get; set; }
+
+        public decimal? PickupLat { get; set; }
+
+        public decimal? PickupLng { get; set; }
     }
 
     public class DeleteBookingRequestDto
@@ -74,6 +94,7 @@ namespace RentACar.Application.DTOs
         public DateOnly Enddate { get; set; }
         public decimal TotalPrice { get; set; } // still validated
         public string BookingStatus { get; set; } = "Pending";
+        public int? DriverId { get; set; }
     }
 
     public class BookingCreationResultDto

--- a/RentACar.Application/Managers/BookingManager.cs
+++ b/RentACar.Application/Managers/BookingManager.cs
@@ -6,8 +6,10 @@ using AutoMapper;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using RentACar.Application.DTOs;
+using RentACar.Application.Services;
 using RentACar.Core.Entities;
 using RentACar.Core.Repositories;
+using Microsoft.Extensions.Options;
 
 namespace RentACar.Application.Managers
 {
@@ -26,6 +28,9 @@ namespace RentACar.Application.Managers
         private readonly ILogger<BookingManager> _logger;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly AuditLogManager _auditLogManager;
+        private readonly IDriverRepository _driverRepository;
+        private readonly IDriverAvailabilityRepository _driverAvailabilityRepository;
+        private readonly DriverFeeOptions _driverFeeOptions;
 
         public BookingManager(
             IEmployeeRepository employeeRepository,
@@ -39,7 +44,10 @@ namespace RentACar.Application.Managers
             IMapper mapper,
             UserManager<IdentityUser> userManager,
             ILogger<BookingManager> logger,
-            AuditLogManager auditLogManager)
+            AuditLogManager auditLogManager,
+            IDriverRepository driverRepository,
+            IDriverAvailabilityRepository driverAvailabilityRepository,
+            IOptions<DriverFeeOptions> driverFeeOptions)
         {
             _employeeRepository = employeeRepository;
             _bookingRepository = bookingRepository;
@@ -53,6 +61,9 @@ namespace RentACar.Application.Managers
             _mapper = mapper;
             _logger = logger;
             _auditLogManager = auditLogManager;
+            _driverRepository = driverRepository;
+            _driverAvailabilityRepository = driverAvailabilityRepository;
+            _driverFeeOptions = driverFeeOptions.Value;
         }
 
         public async Task<BookingCreationResultDto?> MakeBookingAsync(MakeBookingRequestDto requestDto, string loggedInUserId)
@@ -139,7 +150,31 @@ namespace RentACar.Application.Managers
 
             // 🔹 Calculate price
             decimal subtotal = CalculateTotalPrice(car.PricePerDay ?? 0, requestDto.Startdate, requestDto.Enddate);
+            decimal? driverFee = null;
+            int? assignedDriverId = null;
+
+            if (requestDto.HasDriver)
+            {
+                if (!requestDto.PickupLat.HasValue || !requestDto.PickupLng.HasValue)
+                {
+                    _logger.LogWarning("Booking failed: Driver option selected without pickup coordinates.");
+                    return null;
+                }
+
+                driverFee = CalculateDriverFee(subtotal, requestDto.Startdate, requestDto.Enddate);
+                assignedDriverId = await SelectAvailableDriverAsync(requestDto.Startdate, requestDto.Enddate);
+                if (!assignedDriverId.HasValue)
+                {
+                    _logger.LogWarning("Booking failed: No available driver found for requested dates.");
+                    return null;
+                }
+            }
+
             decimal totalPrice = promocode != null ? ApplyPromocode(subtotal, promocode) : subtotal;
+            if (driverFee.HasValue)
+            {
+                totalPrice += driverFee.Value;
+            }
 
             // 🔹 Validate payment method
             var paymentMethod = await _paymentMethodRepository.GetByIdAsync(requestDto.PaymentMethodId);
@@ -172,6 +207,12 @@ namespace RentACar.Application.Managers
                 Enddate = requestDto.Enddate,
                 PromocodeId = promocode?.PromocodeId,
                 TotalPrice = totalPrice,
+                HasDriver = requestDto.HasDriver,
+                DriverId = assignedDriverId,
+                PickupAddress = requestDto.PickupAddress,
+                PickupLat = requestDto.PickupLat,
+                PickupLng = requestDto.PickupLng,
+                DriverFee = driverFee,
                 BookingStatus = "Pending",
                 Subtotal = subtotal,
                 IsBookedByEmployee = isBookedByEmployee,
@@ -202,6 +243,17 @@ namespace RentACar.Application.Managers
             _logger.LogInformation("✅ Booking created with ID: {BookingId}", addedBooking.BookingId);
             
             await _auditLogManager.LogEventAsync("Booking.Created", "Booking", addedBooking.BookingId.ToString(), $"Created new booking for Car {addedBooking.CarId}", null, "Success");
+
+            if (assignedDriverId.HasValue)
+            {
+                await _auditLogManager.LogEventAsync(
+                    "Booking.DriverAssigned",
+                    "Booking",
+                    addedBooking.BookingId.ToString(),
+                    $"Auto-assigned Driver {assignedDriverId.Value} to booking",
+                    null,
+                    "Success");
+            }
             
             var session = await _paymentManager.CreateCheckoutSessionForPaymentAsync(addedPayment);
             if (string.IsNullOrWhiteSpace(session.CheckoutUrl))
@@ -263,6 +315,53 @@ namespace RentACar.Application.Managers
                 return price * (1 - (promocode.DiscountPercentage / 100));
             }
             return price;
+        }
+
+        private decimal CalculateDriverFee(decimal baseSubtotal, DateOnly startDate, DateOnly endDate)
+        {
+            var days = Math.Max(1, (endDate.ToDateTime(TimeOnly.MinValue) - startDate.ToDateTime(TimeOnly.MinValue)).Days);
+            return _driverFeeOptions.Mode switch
+            {
+                "Fixed" => _driverFeeOptions.Rate,
+                "Percentage" => Math.Round((_driverFeeOptions.Rate / 100m) * baseSubtotal, 2, MidpointRounding.AwayFromZero),
+                _ => Math.Round(_driverFeeOptions.Rate * days, 2, MidpointRounding.AwayFromZero)
+            };
+        }
+
+        private async Task<int?> SelectAvailableDriverAsync(DateOnly startDate, DateOnly endDate)
+        {
+            var drivers = await _driverRepository.GetActiveDriversAsync();
+            foreach (var driver in drivers.Where(d => d.IsAvailableManual))
+            {
+                var isAvailable = await IsDriverAvailableAsync(driver.DriverId, startDate, endDate);
+                if (isAvailable)
+                {
+                    return driver.DriverId;
+                }
+            }
+
+            return null;
+        }
+
+        private async Task<bool> IsDriverAvailableAsync(int driverId, DateOnly startDate, DateOnly endDate)
+        {
+            var existingBookings = await _bookingRepository.GetBookingsByDriverIdAsync(driverId);
+            if (existingBookings.Any(b => b.HasDriver && IsBlockingStatus(b.BookingStatus)
+                                          && DatesOverlap(b.Startdate, b.Enddate, startDate, endDate)))
+            {
+                return false;
+            }
+
+            var availabilityBlocks = await _driverAvailabilityRepository.GetByDriverIdAsync(driverId);
+            if (availabilityBlocks.Count == 0)
+            {
+                return true;
+            }
+
+            var start = startDate.ToDateTime(TimeOnly.MinValue);
+            var end = endDate.ToDateTime(TimeOnly.MaxValue);
+            return availabilityBlocks.Any(block =>
+                block.StartTime <= start && block.EndTime >= end);
         }
 
         public async Task<BookingEditDto?> UpdateBookingAsync(BookingEditDto bookingDto)

--- a/RentACar.Application/Managers/DriverManager.cs
+++ b/RentACar.Application/Managers/DriverManager.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+
+namespace RentACar.Application.Managers;
+
+public class DriverManager
+{
+    private readonly IDriverRepository _driverRepository;
+    private readonly IDriverAvailabilityRepository _driverAvailabilityRepository;
+    private readonly IBookingRepository _bookingRepository;
+    private readonly UserManager<IdentityUser> _userManager;
+
+    public DriverManager(
+        IDriverRepository driverRepository,
+        IDriverAvailabilityRepository driverAvailabilityRepository,
+        IBookingRepository bookingRepository,
+        UserManager<IdentityUser> userManager)
+    {
+        _driverRepository = driverRepository;
+        _driverAvailabilityRepository = driverAvailabilityRepository;
+        _bookingRepository = bookingRepository;
+        _userManager = userManager;
+    }
+
+    public Task<Driver?> GetByAspNetUserIdAsync(string aspNetUserId)
+    {
+        return _driverRepository.GetByAspNetUserIdAsync(aspNetUserId);
+    }
+
+    public async Task<List<Driver>> GetAllDriversAsync()
+    {
+        var drivers = await _driverRepository.GetAllAsync();
+        return drivers.ToList();
+    }
+
+    public async Task<List<Driver>> GetAvailableDriversAsync(DateOnly startDate, DateOnly endDate)
+    {
+        var drivers = await _driverRepository.GetActiveDriversAsync();
+        var available = new List<Driver>();
+
+        foreach (var driver in drivers.Where(d => d.IsAvailableManual))
+        {
+            if (await IsDriverAvailableAsync(driver.DriverId, startDate, endDate))
+            {
+                available.Add(driver);
+            }
+        }
+
+        return available;
+    }
+
+    public async Task<bool> IsDriverAvailableAsync(int driverId, DateOnly startDate, DateOnly endDate)
+    {
+        var bookings = await _bookingRepository.GetBookingsByDriverIdAsync(driverId);
+        if (bookings.Any(b => b.HasDriver && IsBlockingStatus(b.BookingStatus) && DatesOverlap(b.Startdate, b.Enddate, startDate, endDate)))
+        {
+            return false;
+        }
+
+        var availability = await _driverAvailabilityRepository.GetByDriverIdAsync(driverId);
+        if (availability.Count == 0)
+        {
+            return true;
+        }
+
+        var start = startDate.ToDateTime(TimeOnly.MinValue);
+        var end = endDate.ToDateTime(TimeOnly.MaxValue);
+        return availability.Any(a => a.StartTime <= start && a.EndTime >= end);
+    }
+
+    public async Task<Driver> CreateDriverAsync(string aspNetUserId, string displayName, string? phoneNumber)
+    {
+        var user = await _userManager.FindByIdAsync(aspNetUserId);
+        if (user == null)
+        {
+            throw new InvalidOperationException("User not found.");
+        }
+
+        var driver = new Driver
+        {
+            AspNetUserId = aspNetUserId,
+            DisplayName = displayName,
+            PhoneNumber = phoneNumber,
+            IsActive = true,
+            IsAvailableManual = true
+        };
+
+        return await _driverRepository.AddAsync(driver);
+    }
+
+    public async Task UpdateDriverAsync(Driver driver)
+    {
+        await _driverRepository.UpdateAsync(driver);
+    }
+
+    public async Task DeactivateDriverAsync(Driver driver)
+    {
+        driver.IsActive = false;
+        driver.IsAvailableManual = false;
+        await _driverRepository.UpdateAsync(driver);
+    }
+
+    private static bool DatesOverlap(DateOnly existingStart, DateOnly existingEnd, DateOnly newStart, DateOnly newEnd)
+    {
+        return existingStart <= newEnd && existingEnd >= newStart;
+    }
+
+    private static bool IsBlockingStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return true;
+        }
+
+        return !status.Equals("returned", StringComparison.OrdinalIgnoreCase)
+               && !status.Equals("rejected", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/RentACar.Application/Services/DriverFeeOptions.cs
+++ b/RentACar.Application/Services/DriverFeeOptions.cs
@@ -1,0 +1,10 @@
+namespace RentACar.Application.Services;
+
+public class DriverFeeOptions
+{
+    public const string SectionName = "DriverFee";
+
+    public string Mode { get; set; } = "PerDay";
+
+    public decimal Rate { get; set; } = 50m;
+}

--- a/RentACar.Core/Entities/AspNetUser.cs
+++ b/RentACar.Core/Entities/AspNetUser.cs
@@ -66,4 +66,7 @@ public partial class AspNetUser
 
     [InverseProperty("User")] // Points back to the 'User' navigation property in the Employee class
     public virtual ICollection<Employee> Employees { get; set; } = new List<Employee>();
+
+    [InverseProperty("User")]
+    public virtual Driver? Driver { get; set; }
 }

--- a/RentACar.Core/Entities/Booking.cs
+++ b/RentACar.Core/Entities/Booking.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -34,6 +35,25 @@ public partial class Booking
     [Column("totalPrice", TypeName = "decimal(18, 2)")]
     public decimal TotalPrice { get; set; }
 
+    [Column("hasDriver")]
+    public bool HasDriver { get; set; }
+
+    [Column("driverID")]
+    public int? DriverId { get; set; }
+
+    [Column("pickupAddress")]
+    [StringLength(255)]
+    public string? PickupAddress { get; set; }
+
+    [Column("pickupLat", TypeName = "decimal(9, 6)")]
+    public decimal? PickupLat { get; set; }
+
+    [Column("pickupLng", TypeName = "decimal(9, 6)")]
+    public decimal? PickupLng { get; set; }
+
+    [Column("driverFee", TypeName = "decimal(18, 2)")]
+    public decimal? DriverFee { get; set; }
+
     [Column("bookingStatus")]
     [StringLength(50)]
     public string? BookingStatus { get; set; }
@@ -53,9 +73,16 @@ public partial class Booking
     [InverseProperty("Bookings")]
     public virtual Employee? Employeebooker { get; set; }
 
+    [ForeignKey("DriverId")]
+    [InverseProperty("Bookings")]
+    public virtual Driver? Driver { get; set; }
+
     [ForeignKey("PromocodeId")]
     [InverseProperty("Bookings")]
     public virtual Promocode? Promocode { get; set; }
 
     public virtual Payment? Payment { get; set; }
+
+    [InverseProperty("Booking")]
+    public virtual ICollection<DriverLocation> DriverLocations { get; set; } = new List<DriverLocation>();
 }

--- a/RentACar.Core/Entities/Driver.cs
+++ b/RentACar.Core/Entities/Driver.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RentACar.Core.Entities;
+
+public partial class Driver
+{
+    [Key]
+    [Column("driverID")]
+    public int DriverId { get; set; }
+
+    [Column("aspNetUserId")]
+    [StringLength(450)]
+    public string AspNetUserId { get; set; } = null!;
+
+    [Column("displayName")]
+    [StringLength(100)]
+    public string DisplayName { get; set; } = null!;
+
+    [Column("phoneNumber")]
+    [StringLength(50)]
+    public string? PhoneNumber { get; set; }
+
+    [Column("isActive")]
+    public bool IsActive { get; set; }
+
+    [Column("isAvailableManual")]
+    public bool IsAvailableManual { get; set; }
+
+    [InverseProperty("Driver")]
+    public virtual ICollection<Booking> Bookings { get; set; } = new List<Booking>();
+
+    [InverseProperty("Driver")]
+    public virtual ICollection<DriverAvailability> DriverAvailabilities { get; set; } = new List<DriverAvailability>();
+
+    [InverseProperty("Driver")]
+    public virtual ICollection<DriverLocation> DriverLocations { get; set; } = new List<DriverLocation>();
+
+    [ForeignKey("AspNetUserId")]
+    [InverseProperty("Driver")]
+    public virtual AspNetUser User { get; set; } = null!;
+}

--- a/RentACar.Core/Entities/DriverAvailability.cs
+++ b/RentACar.Core/Entities/DriverAvailability.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RentACar.Core.Entities;
+
+public partial class DriverAvailability
+{
+    [Key]
+    [Column("driverAvailabilityID")]
+    public int DriverAvailabilityId { get; set; }
+
+    [Column("driverID")]
+    public int DriverId { get; set; }
+
+    [Column("startTime")]
+    public DateTime StartTime { get; set; }
+
+    [Column("endTime")]
+    public DateTime EndTime { get; set; }
+
+    [Column("isRecurringWeekly")]
+    public bool IsRecurringWeekly { get; set; }
+
+    [ForeignKey("DriverId")]
+    [InverseProperty("DriverAvailabilities")]
+    public virtual Driver Driver { get; set; } = null!;
+}

--- a/RentACar.Core/Entities/DriverLocation.cs
+++ b/RentACar.Core/Entities/DriverLocation.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RentACar.Core.Entities;
+
+public partial class DriverLocation
+{
+    [Key]
+    [Column("driverLocationID")]
+    public int DriverLocationId { get; set; }
+
+    [Column("driverID")]
+    public int DriverId { get; set; }
+
+    [Column("bookingID")]
+    public int BookingId { get; set; }
+
+    [Column("latitude", TypeName = "decimal(9, 6)")]
+    public decimal Latitude { get; set; }
+
+    [Column("longitude", TypeName = "decimal(9, 6)")]
+    public decimal Longitude { get; set; }
+
+    [Column("lastUpdatedUtc")]
+    public DateTime LastUpdatedUtc { get; set; }
+
+    [Column("isTrackingActive")]
+    public bool IsTrackingActive { get; set; }
+
+    [ForeignKey("DriverId")]
+    [InverseProperty("DriverLocations")]
+    public virtual Driver Driver { get; set; } = null!;
+
+    [ForeignKey("BookingId")]
+    [InverseProperty("DriverLocations")]
+    public virtual Booking Booking { get; set; } = null!;
+}

--- a/RentACar.Core/Repositories/IBookingRepository.cs
+++ b/RentACar.Core/Repositories/IBookingRepository.cs
@@ -14,6 +14,7 @@ namespace RentACar.Core.Repositories
         Task<List<Booking>> GetBookingsByEmployeeIdAsync(int employeeId);
         Task<List<Booking>> GetBookingsByCustomerIdAsync(int customerId);
         Task<List<Booking>> GetBookingsByCarIdAsync(int carId);
+        Task<List<Booking>> GetBookingsByDriverIdAsync(int driverId);
         Task<List<Booking>> GetBookingsBetweenDatesAsync(DateOnly startDate, DateOnly endDate);
         Task UpdateAsync(Booking booking);
     }

--- a/RentACar.Core/Repositories/IDriverAvailabilityRepository.cs
+++ b/RentACar.Core/Repositories/IDriverAvailabilityRepository.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RentACar.Core.Entities;
+
+namespace RentACar.Core.Repositories;
+
+public interface IDriverAvailabilityRepository : IRepository<DriverAvailability>
+{
+    Task<List<DriverAvailability>> GetByDriverIdAsync(int driverId);
+}

--- a/RentACar.Core/Repositories/IDriverAvailabilityRepository.cs
+++ b/RentACar.Core/Repositories/IDriverAvailabilityRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RentACar.Core.Entities;
+using RentACar.Core.Repositories.Base;
 
 namespace RentACar.Core.Repositories;
 

--- a/RentACar.Core/Repositories/IDriverLocationRepository.cs
+++ b/RentACar.Core/Repositories/IDriverLocationRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RentACar.Core.Entities;
+
+namespace RentACar.Core.Repositories;
+
+public interface IDriverLocationRepository : IRepository<DriverLocation>
+{
+    Task<DriverLocation?> GetLatestByBookingIdAsync(int bookingId);
+    Task<List<DriverLocation>> GetByDriverIdAsync(int driverId);
+}

--- a/RentACar.Core/Repositories/IDriverLocationRepository.cs
+++ b/RentACar.Core/Repositories/IDriverLocationRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RentACar.Core.Entities;
+using RentACar.Core.Repositories.Base;
 
 namespace RentACar.Core.Repositories;
 

--- a/RentACar.Core/Repositories/IDriverRepository.cs
+++ b/RentACar.Core/Repositories/IDriverRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RentACar.Core.Entities;
+
+namespace RentACar.Core.Repositories;
+
+public interface IDriverRepository : IRepository<Driver>
+{
+    Task<Driver?> GetByAspNetUserIdAsync(string aspNetUserId);
+    Task<List<Driver>> GetActiveDriversAsync();
+}

--- a/RentACar.Core/Repositories/IDriverRepository.cs
+++ b/RentACar.Core/Repositories/IDriverRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RentACar.Core.Entities;
+using RentACar.Core.Repositories.Base;
 
 namespace RentACar.Core.Repositories;
 

--- a/RentACar.Infrastructure/Data/Migrations/20260122210442_addedDriver.Designer.cs
+++ b/RentACar.Infrastructure/Data/Migrations/20260122210442_addedDriver.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RentACar.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using RentACar.Infrastructure.Data;
 namespace RentACar.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(RentACarDbContext))]
-    partial class RentACarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260122210442_addedDriver")]
+    partial class addedDriver
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RentACar.Infrastructure/Data/Migrations/20260122210442_addedDriver.cs
+++ b/RentACar.Infrastructure/Data/Migrations/20260122210442_addedDriver.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RentACar.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class addedDriver : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "driverFee",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "driverID",
+                table: "Bookings",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "hasDriver",
+                table: "Bookings",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "pickupAddress",
+                table: "Bookings",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "pickupLat",
+                table: "Bookings",
+                type: "decimal(9,6)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "pickupLng",
+                table: "Bookings",
+                type: "decimal(9,6)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Drivers",
+                columns: table => new
+                {
+                    driverID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    aspNetUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    displayName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    phoneNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    isActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    isAvailableManual = table.Column<bool>(type: "bit", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Drivers", x => x.driverID);
+                    table.ForeignKey(
+                        name: "FK_Drivers_AspNetUsers",
+                        column: x => x.aspNetUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DriverAvailabilities",
+                columns: table => new
+                {
+                    driverAvailabilityID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    driverID = table.Column<int>(type: "int", nullable: false),
+                    startTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    endTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    isRecurringWeekly = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DriverAvailabilities", x => x.driverAvailabilityID);
+                    table.ForeignKey(
+                        name: "FK_DriverAvailabilities_Drivers",
+                        column: x => x.driverID,
+                        principalTable: "Drivers",
+                        principalColumn: "driverID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DriverLocations",
+                columns: table => new
+                {
+                    driverLocationID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    driverID = table.Column<int>(type: "int", nullable: false),
+                    bookingID = table.Column<int>(type: "int", nullable: false),
+                    latitude = table.Column<decimal>(type: "decimal(9,6)", nullable: false),
+                    longitude = table.Column<decimal>(type: "decimal(9,6)", nullable: false),
+                    lastUpdatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    isTrackingActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DriverLocations", x => x.driverLocationID);
+                    table.ForeignKey(
+                        name: "FK_DriverLocations_Bookings",
+                        column: x => x.bookingID,
+                        principalTable: "Bookings",
+                        principalColumn: "BookingID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_DriverLocations_Drivers",
+                        column: x => x.driverID,
+                        principalTable: "Drivers",
+                        principalColumn: "driverID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_driverID",
+                table: "Bookings",
+                column: "driverID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverAvailabilities_driverID",
+                table: "DriverAvailabilities",
+                column: "driverID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverLocations_bookingID",
+                table: "DriverLocations",
+                column: "bookingID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverLocations_driverID",
+                table: "DriverLocations",
+                column: "driverID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Drivers_aspNetUserId",
+                table: "Drivers",
+                column: "aspNetUserId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Drivers",
+                table: "Bookings",
+                column: "driverID",
+                principalTable: "Drivers",
+                principalColumn: "driverID");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Drivers",
+                table: "Bookings");
+
+            migrationBuilder.DropTable(
+                name: "DriverAvailabilities");
+
+            migrationBuilder.DropTable(
+                name: "DriverLocations");
+
+            migrationBuilder.DropTable(
+                name: "Drivers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_driverID",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "driverFee",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "driverID",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "hasDriver",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "pickupAddress",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "pickupLat",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "pickupLng",
+                table: "Bookings");
+        }
+    }
+}

--- a/RentACar.Infrastructure/Data/RentACarDbContext.cs
+++ b/RentACar.Infrastructure/Data/RentACarDbContext.cs
@@ -34,6 +34,9 @@ public partial class RentACarDbContext : DbContext
     public virtual DbSet<CreditCard> CreditCards { get; set; }
     public virtual DbSet<Customer> Customers { get; set; }
     public virtual DbSet<CustomerCreditCard> CustomerCreditCards { get; set; }
+    public virtual DbSet<Driver> Drivers { get; set; }
+    public virtual DbSet<DriverAvailability> DriverAvailabilities { get; set; }
+    public virtual DbSet<DriverLocation> DriverLocations { get; set; }
     public virtual DbSet<Employee> Employees { get; set; }
     public virtual DbSet<Payment> Payments { get; set; }
     public virtual DbSet<PaymentMethod> PaymentMethods { get; set; }
@@ -73,6 +76,7 @@ public partial class RentACarDbContext : DbContext
         modelBuilder.Entity<Booking>(entity =>
         {
             entity.Property(e => e.IsBookedByEmployee).HasDefaultValue(false);
+            entity.Property(e => e.HasDriver).HasDefaultValue(false);
 
             entity.HasOne(d => d.Car).WithMany(p => p.Bookings)
                 .OnDelete(DeleteBehavior.ClientSetNull)
@@ -84,6 +88,9 @@ public partial class RentACarDbContext : DbContext
 
             entity.HasOne(d => d.Employeebooker).WithMany(p => p.Bookings)
                 .HasConstraintName("FK_Bookings_Employees");
+
+            entity.HasOne(d => d.Driver).WithMany(p => p.Bookings)
+                .HasConstraintName("FK_Bookings_Drivers");
 
              entity.HasOne(d => d.Promocode).WithMany(p => p.Bookings)
                 .HasConstraintName("FK_Bookings_Promocodes1");
@@ -112,6 +119,44 @@ public partial class RentACarDbContext : DbContext
             entity.HasOne(d => d.User).WithOne(p => p.Customer)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("FK_Customers_AspNetUsers");
+        });
+
+        modelBuilder.Entity<Driver>(entity =>
+        {
+            entity.Property(e => e.IsActive).HasDefaultValue(true);
+            entity.Property(e => e.IsAvailableManual).HasDefaultValue(true);
+
+            entity.HasOne(d => d.User)
+                .WithOne(p => p.Driver)
+                .HasForeignKey<Driver>(d => d.AspNetUserId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_Drivers_AspNetUsers");
+        });
+
+        modelBuilder.Entity<DriverAvailability>(entity =>
+        {
+            entity.HasOne(d => d.Driver)
+                .WithMany(p => p.DriverAvailabilities)
+                .HasForeignKey(d => d.DriverId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("FK_DriverAvailabilities_Drivers");
+        });
+
+        modelBuilder.Entity<DriverLocation>(entity =>
+        {
+            entity.Property(e => e.LastUpdatedUtc).HasDefaultValueSql("GETUTCDATE()");
+
+            entity.HasOne(d => d.Driver)
+                .WithMany(p => p.DriverLocations)
+                .HasForeignKey(d => d.DriverId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("FK_DriverLocations_Drivers");
+
+            entity.HasOne(d => d.Booking)
+                .WithMany(p => p.DriverLocations)
+                .HasForeignKey(d => d.BookingId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("FK_DriverLocations_Bookings");
         });
 
         modelBuilder.Entity<CustomerCreditCard>(entity =>

--- a/RentACar.Infrastructure/Data/Repository/BookingRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/BookingRepository.cs
@@ -30,6 +30,11 @@ namespace RentACar.Infrastructure.Data.Repository
             return await _dbContext.Bookings.Where(b => b.CarId == carId).ToListAsync();
         }
 
+        public async Task<List<Booking>> GetBookingsByDriverIdAsync(int driverId)
+        {
+            return await _dbContext.Bookings.Where(b => b.DriverId == driverId).ToListAsync();
+        }
+
         public async Task<List<Booking>> GetBookingsBetweenDatesAsync(DateOnly startDate, DateOnly endDate)
         {
             return await _dbContext.Bookings

--- a/RentACar.Infrastructure/Data/Repository/DriverAvailabilityRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/DriverAvailabilityRepository.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+using RentACar.Infrastructure.Data.Repository.Base;
+
+namespace RentACar.Infrastructure.Data.Repository;
+
+public class DriverAvailabilityRepository : Repository<DriverAvailability>, IDriverAvailabilityRepository
+{
+    private readonly RentACarDbContext _dbContext;
+
+    public DriverAvailabilityRepository(RentACarDbContext dbContext) : base(dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<List<DriverAvailability>> GetByDriverIdAsync(int driverId)
+    {
+        return _dbContext.DriverAvailabilities
+            .Where(a => a.DriverId == driverId)
+            .OrderBy(a => a.StartTime)
+            .ToListAsync();
+    }
+}

--- a/RentACar.Infrastructure/Data/Repository/DriverLocationRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/DriverLocationRepository.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+using RentACar.Infrastructure.Data.Repository.Base;
+
+namespace RentACar.Infrastructure.Data.Repository;
+
+public class DriverLocationRepository : Repository<DriverLocation>, IDriverLocationRepository
+{
+    private readonly RentACarDbContext _dbContext;
+
+    public DriverLocationRepository(RentACarDbContext dbContext) : base(dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<DriverLocation?> GetLatestByBookingIdAsync(int bookingId)
+    {
+        return _dbContext.DriverLocations
+            .Where(l => l.BookingId == bookingId)
+            .OrderByDescending(l => l.LastUpdatedUtc)
+            .FirstOrDefaultAsync();
+    }
+
+    public Task<List<DriverLocation>> GetByDriverIdAsync(int driverId)
+    {
+        return _dbContext.DriverLocations
+            .Where(l => l.DriverId == driverId)
+            .OrderByDescending(l => l.LastUpdatedUtc)
+            .ToListAsync();
+    }
+}

--- a/RentACar.Infrastructure/Data/Repository/DriverRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/DriverRepository.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+using RentACar.Infrastructure.Data.Repository.Base;
+
+namespace RentACar.Infrastructure.Data.Repository;
+
+public class DriverRepository : Repository<Driver>, IDriverRepository
+{
+    private readonly RentACarDbContext _dbContext;
+
+    public DriverRepository(RentACarDbContext dbContext) : base(dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<Driver?> GetByAspNetUserIdAsync(string aspNetUserId)
+    {
+        return _dbContext.Drivers
+            .Include(d => d.User)
+            .FirstOrDefaultAsync(d => d.AspNetUserId == aspNetUserId);
+    }
+
+    public Task<List<Driver>> GetActiveDriversAsync()
+    {
+        return _dbContext.Drivers
+            .Include(d => d.User)
+            .Where(d => d.IsActive)
+            .ToListAsync();
+    }
+}

--- a/RentACar.Web/Areas/Driver/Controllers/AvailabilityController.cs
+++ b/RentACar.Web/Areas/Driver/Controllers/AvailabilityController.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+using RentACar.Web.Models.Driver;
+
+namespace RentACar.Web.Areas.Driver.Controllers;
+
+[Area("Driver")]
+[Authorize(Roles = "Driver")]
+public class AvailabilityController : Controller
+{
+    private readonly RentACarDbContext _dbContext;
+    private readonly DriverManager _driverManager;
+
+    public AvailabilityController(RentACarDbContext dbContext, DriverManager driverManager)
+    {
+        _dbContext = dbContext;
+        _driverManager = driverManager;
+    }
+
+    [HttpGet("/Driver/Availability")]
+    public async Task<IActionResult> Index()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var blocks = await _dbContext.DriverAvailabilities
+            .Where(a => a.DriverId == driver.DriverId)
+            .OrderBy(a => a.StartTime)
+            .ToListAsync();
+
+        var viewModel = blocks.Select(a => new DriverAvailabilityBlockViewModel
+        {
+            DriverAvailabilityId = a.DriverAvailabilityId,
+            StartTime = a.StartTime,
+            EndTime = a.EndTime,
+            IsRecurringWeekly = a.IsRecurringWeekly
+        }).ToList();
+
+        return View("~/Areas/Driver/Views/Availability/Index.cshtml", viewModel);
+    }
+
+    [HttpPost("/Driver/Availability/Create")]
+    public async Task<IActionResult> Create(DriverAvailabilityBlockViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            TempData["AvailabilityError"] = "Please provide valid availability times.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        if (model.EndTime <= model.StartTime)
+        {
+            TempData["AvailabilityError"] = "End time must be after start time.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var overlaps = await _dbContext.DriverAvailabilities
+            .Where(a => a.DriverId == driver.DriverId && a.StartTime < model.EndTime && a.EndTime > model.StartTime)
+            .AnyAsync();
+
+        if (overlaps)
+        {
+            TempData["AvailabilityError"] = "Availability block overlaps an existing block.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var bookingConflict = await _dbContext.Bookings
+            .Where(b => b.DriverId == driver.DriverId && b.Startdate.ToDateTime(TimeOnly.MinValue) < model.EndTime
+                        && b.Enddate.ToDateTime(TimeOnly.MaxValue) > model.StartTime)
+            .AnyAsync();
+
+        if (bookingConflict)
+        {
+            TempData["AvailabilityError"] = "Availability conflicts with an existing booking.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var entity = new Core.Entities.DriverAvailability
+        {
+            DriverId = driver.DriverId,
+            StartTime = model.StartTime,
+            EndTime = model.EndTime,
+            IsRecurringWeekly = model.IsRecurringWeekly
+        };
+
+        _dbContext.DriverAvailabilities.Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        TempData["AvailabilitySuccess"] = "Availability saved.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("/Driver/Availability/Edit")]
+    public async Task<IActionResult> Edit(DriverAvailabilityBlockViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            TempData["AvailabilityError"] = "Please provide valid availability times.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var existing = await _dbContext.DriverAvailabilities
+            .FirstOrDefaultAsync(a => a.DriverAvailabilityId == model.DriverAvailabilityId && a.DriverId == driver.DriverId);
+
+        if (existing == null)
+        {
+            return NotFound();
+        }
+
+        var overlaps = await _dbContext.DriverAvailabilities
+            .Where(a => a.DriverId == driver.DriverId && a.DriverAvailabilityId != model.DriverAvailabilityId
+                        && a.StartTime < model.EndTime && a.EndTime > model.StartTime)
+            .AnyAsync();
+
+        if (overlaps)
+        {
+            TempData["AvailabilityError"] = "Availability block overlaps an existing block.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var bookingConflict = await _dbContext.Bookings
+            .Where(b => b.DriverId == driver.DriverId && b.Startdate.ToDateTime(TimeOnly.MinValue) < model.EndTime
+                        && b.Enddate.ToDateTime(TimeOnly.MaxValue) > model.StartTime)
+            .AnyAsync();
+
+        if (bookingConflict)
+        {
+            TempData["AvailabilityError"] = "Availability conflicts with an existing booking.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        existing.StartTime = model.StartTime;
+        existing.EndTime = model.EndTime;
+        existing.IsRecurringWeekly = model.IsRecurringWeekly;
+
+        _dbContext.DriverAvailabilities.Update(existing);
+        await _dbContext.SaveChangesAsync();
+
+        TempData["AvailabilitySuccess"] = "Availability updated.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("/Driver/Availability/Delete")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var existing = await _dbContext.DriverAvailabilities
+            .FirstOrDefaultAsync(a => a.DriverAvailabilityId == id && a.DriverId == driver.DriverId);
+
+        if (existing == null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.DriverAvailabilities.Remove(existing);
+        await _dbContext.SaveChangesAsync();
+        TempData["AvailabilitySuccess"] = "Availability deleted.";
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/RentACar.Web/Areas/Driver/Controllers/BookingsController.cs
+++ b/RentACar.Web/Areas/Driver/Controllers/BookingsController.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+using RentACar.Web.Models.Driver;
+
+namespace RentACar.Web.Areas.Driver.Controllers;
+
+[Area("Driver")]
+[Authorize(Roles = "Driver")]
+public class BookingsController : Controller
+{
+    private readonly RentACarDbContext _dbContext;
+    private readonly DriverManager _driverManager;
+    private readonly AuditLogManager _auditLogManager;
+
+    public BookingsController(RentACarDbContext dbContext, DriverManager driverManager, AuditLogManager auditLogManager)
+    {
+        _dbContext = dbContext;
+        _driverManager = driverManager;
+        _auditLogManager = auditLogManager;
+    }
+
+    [HttpGet("/Driver/Bookings")]
+    public async Task<IActionResult> Index(string? status, DateOnly? date)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var bookingsQuery = _dbContext.Bookings
+            .Include(b => b.Customer)
+            .Include(b => b.Car)
+            .Where(b => b.DriverId == driver.DriverId);
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            bookingsQuery = bookingsQuery.Where(b => b.BookingStatus == status);
+        }
+
+        if (date.HasValue)
+        {
+            bookingsQuery = bookingsQuery.Where(b => b.Startdate <= date && b.Enddate >= date);
+        }
+
+        var bookings = await bookingsQuery.OrderByDescending(b => b.Startdate).ToListAsync();
+
+        var viewModel = bookings.Select(b => new DriverBookingListItemViewModel
+        {
+            BookingId = b.BookingId,
+            CustomerName = b.Customer?.Name,
+            CarModel = b.Car?.ModelName,
+            StartDate = b.Startdate,
+            EndDate = b.Enddate,
+            Status = b.BookingStatus,
+            PickupAddress = b.PickupAddress
+        }).ToList();
+
+        ViewBag.SelectedStatus = status;
+        ViewBag.SelectedDate = date?.ToString("yyyy-MM-dd");
+
+        return View("~/Areas/Driver/Views/Bookings/Index.cshtml", viewModel);
+    }
+
+    [HttpGet("/Driver/Bookings/{id:int}")]
+    public async Task<IActionResult> Details(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var booking = await _dbContext.Bookings
+            .Include(b => b.Customer)
+            .Include(b => b.Car)
+            .FirstOrDefaultAsync(b => b.BookingId == id && b.DriverId == driver.DriverId);
+
+        if (booking == null)
+        {
+            return NotFound();
+        }
+
+        var location = await _dbContext.DriverLocations
+            .Where(l => l.BookingId == booking.BookingId && l.DriverId == driver.DriverId)
+            .OrderByDescending(l => l.LastUpdatedUtc)
+            .FirstOrDefaultAsync();
+
+        var viewModel = new DriverBookingDetailsViewModel
+        {
+            BookingId = booking.BookingId,
+            BookingStatus = booking.BookingStatus,
+            StartDate = booking.Startdate,
+            EndDate = booking.Enddate,
+            CustomerName = booking.Customer?.Name,
+            CustomerEmail = booking.Customer?.Email,
+            CustomerPhone = booking.Customer?.PhoneNumber,
+            CarModel = booking.Car?.ModelName,
+            CarPlateNumber = booking.Car?.PlateNumber,
+            PickupAddress = booking.PickupAddress,
+            PickupLat = booking.PickupLat,
+            PickupLng = booking.PickupLng,
+            IsTrackingActive = location?.IsTrackingActive ?? false,
+            LastTrackingUpdateUtc = location?.LastUpdatedUtc
+        };
+
+        return View("~/Areas/Driver/Views/Bookings/Details.cshtml", viewModel);
+    }
+
+    [HttpPost("/Driver/Bookings/{id:int}/StartTracking")]
+    public async Task<IActionResult> StartTracking(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var booking = await _dbContext.Bookings.FirstOrDefaultAsync(b => b.BookingId == id && b.DriverId == driver.DriverId);
+        if (booking == null)
+        {
+            return NotFound();
+        }
+
+        var location = await _dbContext.DriverLocations
+            .FirstOrDefaultAsync(l => l.BookingId == booking.BookingId && l.DriverId == driver.DriverId);
+
+        if (location == null)
+        {
+            location = new Core.Entities.DriverLocation
+            {
+                BookingId = booking.BookingId,
+                DriverId = driver.DriverId,
+                Latitude = booking.PickupLat ?? 0,
+                Longitude = booking.PickupLng ?? 0,
+                LastUpdatedUtc = DateTime.UtcNow,
+                IsTrackingActive = true
+            };
+            _dbContext.DriverLocations.Add(location);
+        }
+        else
+        {
+            location.IsTrackingActive = true;
+            location.LastUpdatedUtc = DateTime.UtcNow;
+            _dbContext.DriverLocations.Update(location);
+        }
+
+        await _dbContext.SaveChangesAsync();
+        await _auditLogManager.LogEventAsync("DriverTracking.Started", "Booking", booking.BookingId.ToString(), $"Driver {driver.DriverId} started tracking.", null, "Success");
+
+        return RedirectToAction(nameof(Details), new { id });
+    }
+
+    [HttpPost("/Driver/Bookings/{id:int}/StopTracking")]
+    public async Task<IActionResult> StopTracking(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var location = await _dbContext.DriverLocations
+            .FirstOrDefaultAsync(l => l.BookingId == id && l.DriverId == driver.DriverId);
+
+        if (location == null)
+        {
+            return NotFound();
+        }
+
+        location.IsTrackingActive = false;
+        location.LastUpdatedUtc = DateTime.UtcNow;
+        _dbContext.DriverLocations.Update(location);
+        await _dbContext.SaveChangesAsync();
+        await _auditLogManager.LogEventAsync("DriverTracking.Stopped", "Booking", id.ToString(), $"Driver {driver.DriverId} stopped tracking.", null, "Success");
+
+        return RedirectToAction(nameof(Details), new { id });
+    }
+}

--- a/RentACar.Web/Areas/Driver/Controllers/BookingsController.cs
+++ b/RentACar.Web/Areas/Driver/Controllers/BookingsController.cs
@@ -82,6 +82,7 @@ public class BookingsController : Controller
 
         var booking = await _dbContext.Bookings
             .Include(b => b.Customer)
+                .ThenInclude(c => c.User)
             .Include(b => b.Car)
             .FirstOrDefaultAsync(b => b.BookingId == id && b.DriverId == driver.DriverId);
 
@@ -102,8 +103,8 @@ public class BookingsController : Controller
             StartDate = booking.Startdate,
             EndDate = booking.Enddate,
             CustomerName = booking.Customer?.Name,
-            CustomerEmail = booking.Customer?.Email,
-            CustomerPhone = booking.Customer?.PhoneNumber,
+            CustomerEmail = booking.Customer?.User?.Email,
+            CustomerPhone = booking.Customer?.User?.PhoneNumber,
             CarModel = booking.Car?.ModelName,
             CarPlateNumber = booking.Car?.PlateNumber,
             PickupAddress = booking.PickupAddress,

--- a/RentACar.Web/Areas/Driver/Controllers/CalendarController.cs
+++ b/RentACar.Web/Areas/Driver/Controllers/CalendarController.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+using RentACar.Web.Models.Driver;
+
+namespace RentACar.Web.Areas.Driver.Controllers;
+
+[Area("Driver")]
+[Authorize(Roles = "Driver")]
+public class CalendarController : Controller
+{
+    private readonly RentACarDbContext _dbContext;
+    private readonly DriverManager _driverManager;
+
+    public CalendarController(RentACarDbContext dbContext, DriverManager driverManager)
+    {
+        _dbContext = dbContext;
+        _driverManager = driverManager;
+    }
+
+    [HttpGet("/Driver/Calendar")]
+    public async Task<IActionResult> Index(int? year, int? month)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var driver = userId != null ? await _driverManager.GetByAspNetUserIdAsync(userId) : null;
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var targetMonth = new DateTime(year ?? DateTime.Today.Year, month ?? DateTime.Today.Month, 1);
+        var monthStart = DateOnly.FromDateTime(targetMonth);
+        var monthEnd = DateOnly.FromDateTime(targetMonth.AddMonths(1).AddDays(-1));
+
+        var bookings = await _dbContext.Bookings
+            .Include(b => b.Customer)
+            .Where(b => b.DriverId == driver.DriverId && b.Startdate <= monthEnd && b.Enddate >= monthStart)
+            .OrderBy(b => b.Startdate)
+            .ToListAsync();
+
+        var availability = await _dbContext.DriverAvailabilities
+            .Where(a => a.DriverId == driver.DriverId)
+            .OrderBy(a => a.StartTime)
+            .ToListAsync();
+
+        var viewModel = new DriverCalendarViewModel
+        {
+            Month = targetMonth,
+            Bookings = bookings.Select(b => new DriverBookingListItemViewModel
+            {
+                BookingId = b.BookingId,
+                CustomerName = b.Customer?.Name,
+                StartDate = b.Startdate,
+                EndDate = b.Enddate,
+                Status = b.BookingStatus,
+                PickupAddress = b.PickupAddress
+            }).ToList(),
+            AvailabilityBlocks = availability.Select(a => new DriverAvailabilityBlockViewModel
+            {
+                DriverAvailabilityId = a.DriverAvailabilityId,
+                StartTime = a.StartTime,
+                EndTime = a.EndTime,
+                IsRecurringWeekly = a.IsRecurringWeekly
+            }).ToList()
+        };
+
+        return View("~/Areas/Driver/Views/Calendar/Index.cshtml", viewModel);
+    }
+}

--- a/RentACar.Web/Areas/Driver/Controllers/DashboardController.cs
+++ b/RentACar.Web/Areas/Driver/Controllers/DashboardController.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+using RentACar.Web.Models.Driver;
+
+namespace RentACar.Web.Areas.Driver.Controllers;
+
+[Area("Driver")]
+[Authorize(Roles = "Driver")]
+public class DashboardController : Controller
+{
+    private readonly RentACarDbContext _dbContext;
+    private readonly DriverManager _driverManager;
+
+    public DashboardController(RentACarDbContext dbContext, DriverManager driverManager)
+    {
+        _dbContext = dbContext;
+        _driverManager = driverManager;
+    }
+
+    [HttpGet("/Driver/Dashboard")]
+    public async Task<IActionResult> Index()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized();
+        }
+
+        var driver = await _driverManager.GetByAspNetUserIdAsync(userId);
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var bookings = await _dbContext.Bookings
+            .Include(b => b.Customer)
+            .Include(b => b.Car)
+            .Where(b => b.DriverId == driver.DriverId)
+            .OrderBy(b => b.Startdate)
+            .ToListAsync();
+
+        var todayBookings = bookings
+            .Where(b => b.Startdate <= today && b.Enddate >= today)
+            .Select(b => new DriverBookingListItemViewModel
+            {
+                BookingId = b.BookingId,
+                CustomerName = b.Customer?.Name,
+                CarModel = b.Car?.ModelName,
+                StartDate = b.Startdate,
+                EndDate = b.Enddate,
+                Status = b.BookingStatus,
+                PickupAddress = b.PickupAddress
+            })
+            .ToList();
+
+        var upcoming = bookings
+            .Where(b => b.Startdate > today)
+            .Take(5)
+            .Select(b => new DriverBookingListItemViewModel
+            {
+                BookingId = b.BookingId,
+                CustomerName = b.Customer?.Name,
+                CarModel = b.Car?.ModelName,
+                StartDate = b.Startdate,
+                EndDate = b.Enddate,
+                Status = b.BookingStatus,
+                PickupAddress = b.PickupAddress
+            })
+            .ToList();
+
+        var isOnTrip = bookings.Any(b => b.Startdate <= today && b.Enddate >= today && !string.Equals(b.BookingStatus, "Returned", StringComparison.OrdinalIgnoreCase));
+
+        var viewModel = new DriverDashboardViewModel
+        {
+            DriverName = driver.DisplayName,
+            IsAvailableManual = driver.IsAvailableManual,
+            IsOnTrip = isOnTrip,
+            TodayBookings = todayBookings,
+            UpcomingBookings = upcoming
+        };
+
+        return View("~/Areas/Driver/Views/Dashboard/Index.cshtml", viewModel);
+    }
+
+    [HttpPost("/Driver/Dashboard/ToggleAvailability")]
+    public async Task<IActionResult> ToggleAvailability()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized();
+        }
+
+        var driver = await _driverManager.GetByAspNetUserIdAsync(userId);
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        driver.IsAvailableManual = !driver.IsAvailableManual;
+        await _driverManager.UpdateDriverAsync(driver);
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/RentACar.Web/Areas/Driver/Views/Availability/Index.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Availability/Index.cshtml
@@ -1,0 +1,130 @@
+@model List<DriverAvailabilityBlockViewModel>
+@{
+    ViewData["Title"] = "Availability";
+}
+
+@if (TempData["AvailabilityError"] != null)
+{
+    <div class="alert alert-danger">@TempData["AvailabilityError"]</div>
+}
+@if (TempData["AvailabilitySuccess"] != null)
+{
+    <div class="alert alert-success">@TempData["AvailabilitySuccess"]</div>
+}
+
+<div class="driver-card mb-4">
+    <h4>Add Availability</h4>
+    <form method="post" action="/Driver/Availability/Create" class="row g-3">
+        <div class="col-md-5">
+            <label class="form-label">Start</label>
+            <input type="datetime-local" name="StartTime" class="form-control" required />
+        </div>
+        <div class="col-md-5">
+            <label class="form-label">End</label>
+            <input type="datetime-local" name="EndTime" class="form-control" required />
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="IsRecurringWeekly" id="recurringWeekly" />
+                <label class="form-check-label" for="recurringWeekly">Weekly</label>
+            </div>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-warning">Save Availability</button>
+        </div>
+    </form>
+</div>
+
+<div class="driver-card">
+    <h5>Your Availability Blocks</h5>
+    @if (!Model.Any())
+    {
+        <p class="text-muted">No availability blocks yet.</p>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-dark table-hover align-middle">
+                <thead>
+                    <tr>
+                        <th>Start</th>
+                        <th>End</th>
+                        <th>Recurring</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var block in Model)
+                    {
+                        <tr>
+                            <td>@block.StartTime:g</td>
+                            <td>@block.EndTime:g</td>
+                            <td>@(block.IsRecurringWeekly ? "Weekly" : "-")</td>
+                            <td class="text-end">
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-light me-2"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#editAvailabilityModal"
+                                        data-id="@block.DriverAvailabilityId"
+                                        data-start="@block.StartTime.ToString("yyyy-MM-ddTHH:mm")"
+                                        data-end="@block.EndTime.ToString("yyyy-MM-ddTHH:mm")"
+                                        data-recurring="@block.IsRecurringWeekly">
+                                    Edit
+                                </button>
+                                <form method="post" action="/Driver/Availability/Delete" class="d-inline">
+                                    <input type="hidden" name="id" value="@block.DriverAvailabilityId" />
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>
+
+<div class="modal fade" id="editAvailabilityModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content bg-dark text-white">
+            <form method="post" action="/Driver/Availability/Edit">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Availability</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="DriverAvailabilityId" id="editAvailabilityId" />
+                    <div class="mb-3">
+                        <label class="form-label">Start</label>
+                        <input type="datetime-local" name="StartTime" id="editStartTime" class="form-control" required />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">End</label>
+                        <input type="datetime-local" name="EndTime" id="editEndTime" class="form-control" required />
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="IsRecurringWeekly" id="editRecurringWeekly" />
+                        <label class="form-check-label" for="editRecurringWeekly">Recurring weekly</label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-warning">Save changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        const editModal = document.getElementById('editAvailabilityModal');
+        editModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            document.getElementById('editAvailabilityId').value = button.dataset.id;
+            document.getElementById('editStartTime').value = button.dataset.start;
+            document.getElementById('editEndTime').value = button.dataset.end;
+            document.getElementById('editRecurringWeekly').checked = button.dataset.recurring === 'True';
+        });
+    </script>
+}

--- a/RentACar.Web/Areas/Driver/Views/Bookings/Details.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Bookings/Details.cshtml
@@ -1,0 +1,122 @@
+@inject IConfiguration Configuration
+@model DriverBookingDetailsViewModel
+@{
+    ViewData["Title"] = $"Booking #{Model.BookingId}";
+    var mapsKey = Configuration["GoogleMaps:ApiKey"] ?? string.Empty;
+}
+
+<div class="driver-card mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h4 class="mb-1">Booking Details & Tracking</h4>
+            <small class="text-muted">Booking #@Model.BookingId · @Model.BookingStatus</small>
+        </div>
+        <div>
+            <form method="post" action="/Driver/Bookings/@Model.BookingId/StartTracking" class="d-inline">
+                <button class="btn btn-warning" type="submit">Start Tracking</button>
+            </form>
+            <form method="post" action="/Driver/Bookings/@Model.BookingId/StopTracking" class="d-inline ms-2">
+                <button class="btn btn-outline-danger" type="submit">Stop</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="driver-card">
+                <h5>Customer</h5>
+                <p class="mb-1">@Model.CustomerName</p>
+                <small class="text-muted d-block">@Model.CustomerEmail</small>
+                <small class="text-muted d-block">@Model.CustomerPhone</small>
+                <div class="mt-3">
+                    <span class="badge bg-secondary">Car: @Model.CarModel</span>
+                    <span class="badge bg-dark">@Model.CarPlateNumber</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="driver-card">
+                <h5>Pickup Location</h5>
+                <p class="text-muted mb-2">@Model.PickupAddress</p>
+                <div id="pickupMap" style="height: 240px; border-radius: 12px;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="driver-card">
+    <h5>Tracking Control Center</h5>
+    <p class="text-muted">Live updates to the customer are sent every few seconds while tracking is active.</p>
+    <div class="d-flex gap-3 align-items-center">
+        <span class="badge @(Model.IsTrackingActive ? "bg-success" : "bg-secondary")">
+            @(Model.IsTrackingActive ? "Tracking Active" : "Tracking Off")
+        </span>
+        <span class="text-muted">Last update: @(Model.LastTrackingUpdateUtc?.ToString("HH:mm:ss") ?? "N/A")</span>
+    </div>
+    <div class="mt-3">
+        <button class="btn btn-outline-warning" type="button" id="shareLocationBtn">Share current location</button>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=@mapsKey&callback=initPickupMap"></script>
+    <script>
+        let pickupMap;
+        let pickupMarker;
+        let driverMarker;
+        const bookingId = @Model.BookingId;
+
+        function initPickupMap() {
+            const pickupLat = Number('@Model.PickupLat');
+            const pickupLng = Number('@Model.PickupLng');
+            const center = { lat: pickupLat || 25.2048, lng: pickupLng || 55.2708 };
+            pickupMap = new google.maps.Map(document.getElementById('pickupMap'), {
+                center,
+                zoom: pickupLat && pickupLng ? 14 : 10,
+                styles: [
+                    { elementType: 'geometry', stylers: [{ color: '#1f1f1f' }] },
+                    { elementType: 'labels.text.fill', stylers: [{ color: '#f5f5f5' }] }
+                ]
+            });
+
+            if (pickupLat && pickupLng) {
+                pickupMarker = new google.maps.Marker({
+                    position: { lat: pickupLat, lng: pickupLng },
+                    map: pickupMap,
+                    title: 'Pickup Location'
+                });
+            }
+        }
+
+        const connection = new signalR.HubConnectionBuilder()
+            .withUrl('/hubs/driver-tracking')
+            .withAutomaticReconnect()
+            .build();
+
+        async function startConnection() {
+            try {
+                await connection.start();
+            } catch (err) {
+                console.error(err);
+                setTimeout(startConnection, 3000);
+            }
+        }
+
+        async function sendLocationUpdate(position) {
+            const lat = position.coords.latitude;
+            const lng = position.coords.longitude;
+            await connection.invoke('SendLocationUpdate', bookingId, lat, lng);
+        }
+
+        document.getElementById('shareLocationBtn').addEventListener('click', () => {
+            if (!navigator.geolocation) {
+                alert('Geolocation is not available.');
+                return;
+            }
+            navigator.geolocation.getCurrentPosition(sendLocationUpdate);
+        });
+
+        startConnection();
+    </script>
+}

--- a/RentACar.Web/Areas/Driver/Views/Bookings/Index.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Bookings/Index.cshtml
@@ -1,0 +1,61 @@
+@model List<DriverBookingListItemViewModel>
+@{
+    ViewData["Title"] = "Driver Bookings";
+}
+
+<div class="driver-card mb-4">
+    <form class="row g-3 align-items-end" method="get" action="/Driver/Bookings">
+        <div class="col-md-4">
+            <label class="form-label">Filter by Status</label>
+            <input type="text" name="status" class="form-control" value="@ViewBag.SelectedStatus" placeholder="Booked / Pending / Returned" />
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Filter by Date</label>
+            <input type="date" name="date" class="form-control" value="@ViewBag.SelectedDate" />
+        </div>
+        <div class="col-md-4">
+            <button type="submit" class="btn btn-warning">Search</button>
+            <a href="/Driver/Bookings" class="btn btn-outline-light ms-2">Reset</a>
+        </div>
+    </form>
+</div>
+
+<div class="driver-card">
+    <h5 class="mb-3">Assigned Bookings</h5>
+    @if (!Model.Any())
+    {
+        <p class="text-muted mb-0">No bookings found.</p>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-dark table-hover align-middle">
+                <thead>
+                    <tr>
+                        <th>Booking</th>
+                        <th>Customer</th>
+                        <th>Dates</th>
+                        <th>Status</th>
+                        <th>Pickup</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var booking in Model)
+                    {
+                        <tr>
+                            <td>#@booking.BookingId</td>
+                            <td>@booking.CustomerName</td>
+                            <td>@booking.StartDate:MMM dd - @booking.EndDate:MMM dd</td>
+                            <td>@booking.Status</td>
+                            <td>@booking.PickupAddress</td>
+                            <td>
+                                <a class="btn btn-sm btn-outline-warning" href="/Driver/Bookings/@booking.BookingId">Details</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>

--- a/RentACar.Web/Areas/Driver/Views/Calendar/Index.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Calendar/Index.cshtml
@@ -1,0 +1,64 @@
+@model DriverCalendarViewModel
+@{
+    ViewData["Title"] = "Driver Calendar";
+    var monthLabel = Model.Month.ToString("MMMM yyyy");
+}
+
+<div class="driver-card mb-4">
+    <div class="d-flex justify-content-between align-items-center">
+        <h4 class="mb-0">Calendar & Schedule</h4>
+        <div>
+            <a class="btn btn-outline-light" href="/Driver/Calendar?year=@Model.Month.AddMonths(-1).Year&month=@Model.Month.AddMonths(-1).Month">&laquo; Prev</a>
+            <span class="mx-3">@monthLabel</span>
+            <a class="btn btn-outline-light" href="/Driver/Calendar?year=@Model.Month.AddMonths(1).Year&month=@Model.Month.AddMonths(1).Month">Next &raquo;</a>
+        </div>
+    </div>
+    <p class="text-muted mt-2">Manage your bookings and availability blocks in a single view.</p>
+</div>
+
+<div class="driver-card">
+    <div class="row">
+        <div class="col-lg-8">
+            <h5>Bookings</h5>
+            @if (!Model.Bookings.Any())
+            {
+                <p class="text-muted">No bookings scheduled for this month.</p>
+            }
+            else
+            {
+                <ul class="list-group list-group-flush">
+                    @foreach (var booking in Model.Bookings)
+                    {
+                        <li class="list-group-item bg-transparent text-white border-secondary">
+                            <strong>#@booking.BookingId</strong>
+                            <span class="ms-2 text-muted">@booking.StartDate:MMM dd - @booking.EndDate:MMM dd</span>
+                            <span class="ms-2 text-warning">@booking.CustomerName</span>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+        <div class="col-lg-4">
+            <h5>Availability Blocks</h5>
+            @if (!Model.AvailabilityBlocks.Any())
+            {
+                <p class="text-muted">No availability blocks added.</p>
+            }
+            else
+            {
+                <ul class="list-group list-group-flush">
+                    @foreach (var block in Model.AvailabilityBlocks)
+                    {
+                        <li class="list-group-item bg-transparent text-white border-secondary">
+                            @block.StartTime:g - @block.EndTime:g
+                            @if (block.IsRecurringWeekly)
+                            {
+                                <span class="badge bg-warning text-dark ms-2">Weekly</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+    </div>
+</div>

--- a/RentACar.Web/Areas/Driver/Views/Dashboard/Index.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Dashboard/Index.cshtml
@@ -1,0 +1,84 @@
+@model DriverDashboardViewModel
+@{
+    ViewData["Title"] = "Driver Dashboard";
+}
+
+<div class="row g-4">
+    <div class="col-lg-8">
+        <div class="driver-card mb-4">
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    <h4 class="mb-1">Today's Bookings</h4>
+                    <p class="text-muted mb-0">You have @Model.TodayBookings.Count booking(s) scheduled today.</p>
+                </div>
+                <form method="post" action="/Driver/Dashboard/ToggleAvailability">
+                    <button type="submit" class="btn btn-sm @(Model.IsAvailableManual ? "btn-success" : "btn-outline-light")">
+                        @(Model.IsAvailableManual ? "Available" : "Unavailable")
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div class="driver-card">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0">Upcoming Assignments</h5>
+                <a class="btn btn-outline-warning btn-sm" href="/Driver/Bookings">View all</a>
+            </div>
+            @if (!Model.UpcomingBookings.Any())
+            {
+                <p class="text-muted mb-0">No upcoming bookings yet.</p>
+            }
+            else
+            {
+                <div class="list-group list-group-flush">
+                    @foreach (var booking in Model.UpcomingBookings)
+                    {
+                        <a class="list-group-item list-group-item-action bg-transparent text-white border-secondary" href="/Driver/Bookings/@booking.BookingId">
+                            <div class="d-flex justify-content-between">
+                                <div>
+                                    <strong>Booking #@booking.BookingId</strong>
+                                    <div class="text-muted">@booking.CustomerName · @booking.CarModel</div>
+                                </div>
+                                <div class="text-warning">@booking.StartDate:MMM dd - @booking.EndDate:MMM dd</div>
+                            </div>
+                        </a>
+                    }
+                </div>
+            }
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="driver-card mb-4">
+            <h5>Status</h5>
+            <p class="text-muted mb-2">Hello @Model.DriverName</p>
+            <div class="d-flex align-items-center gap-2">
+                <span class="badge @(Model.IsOnTrip ? "bg-danger" : "bg-success")">
+                    @(Model.IsOnTrip ? "On Trip" : "Off Trip")
+                </span>
+                <span class="badge @(Model.IsAvailableManual ? "bg-warning text-dark" : "bg-secondary")">
+                    @(Model.IsAvailableManual ? "Available" : "Unavailable")
+                </span>
+            </div>
+        </div>
+
+        <div class="driver-card">
+            <h5>Today's Trips</h5>
+            @if (!Model.TodayBookings.Any())
+            {
+                <p class="text-muted mb-0">No trips today. Stay ready for updates.</p>
+            }
+            else
+            {
+                <ul class="list-unstyled mb-0">
+                    @foreach (var booking in Model.TodayBookings)
+                    {
+                        <li class="mb-3">
+                            <div class="fw-semibold">#@booking.BookingId · @booking.CustomerName</div>
+                            <small class="text-muted">@booking.PickupAddress</small>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+    </div>
+</div>

--- a/RentACar.Web/Areas/Driver/Views/Shared/_DriverLayout.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/Shared/_DriverLayout.cshtml
@@ -1,0 +1,55 @@
+@{
+    var title = ViewData["Title"] ?? "Driver Portal";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@title - RentACar Driver</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+    <style>
+        body { background: #0f0f0f; color: #f2f2f2; }
+        .driver-sidebar { width: 240px; background: #151515; min-height: 100vh; padding: 24px; }
+        .driver-sidebar a { color: #f5f5f5; text-decoration: none; display: block; padding: 10px 12px; border-radius: 8px; margin-bottom: 8px; }
+        .driver-sidebar a.active, .driver-sidebar a:hover { background: #f7c948; color: #1a1a1a; }
+        .driver-header { padding: 20px 32px; background: #151515; border-bottom: 1px solid #232323; }
+        .driver-content { padding: 32px; }
+        .driver-card { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 16px; padding: 20px; }
+    </style>
+</head>
+<body>
+    <div class="d-flex">
+        <aside class="driver-sidebar">
+            <div class="mb-4">
+                <h4 class="text-warning mb-0"><i class="fa-solid fa-car-side me-2"></i>Driver Portal</h4>
+                <small class="text-muted">RentACar</small>
+            </div>
+            <a href="/Driver/Dashboard" class="@(ViewContext.RouteData.Values["controller"]?.ToString() == "Dashboard" ? "active" : "")">Dashboard</a>
+            <a href="/Driver/Bookings" class="@(ViewContext.RouteData.Values["controller"]?.ToString() == "Bookings" ? "active" : "")">Bookings</a>
+            <a href="/Driver/Calendar" class="@(ViewContext.RouteData.Values["controller"]?.ToString() == "Calendar" ? "active" : "")">Calendar</a>
+            <a href="/Driver/Availability" class="@(ViewContext.RouteData.Values["controller"]?.ToString() == "Availability" ? "active" : "")">Availability</a>
+            <a href="/Bookings/MyBookings" class="text-muted">Switch to Customer</a>
+        </aside>
+        <main class="flex-grow-1">
+            <div class="driver-header d-flex justify-content-between align-items-center">
+                <div>
+                    <h3 class="mb-0">@title</h3>
+                    <small class="text-muted">Manage your trips, tracking, and availability.</small>
+                </div>
+                <div>
+                    <span class="badge bg-warning text-dark">Driver</span>
+                </div>
+            </div>
+            <div class="driver-content">
+                @RenderBody()
+            </div>
+        </main>
+    </div>
+
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/RentACar.Web/Areas/Driver/Views/_ViewImports.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using RentACar.Web.Models.Driver
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/RentACar.Web/Areas/Driver/Views/_ViewStart.cshtml
+++ b/RentACar.Web/Areas/Driver/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "~/Areas/Driver/Views/Shared/_DriverLayout.cshtml";
+}

--- a/RentACar.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/RentACar.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -171,7 +171,11 @@ namespace RentACar.Web.Areas.Identity.Pages.Account
                     var roles = await _userManager.GetRolesAsync(user);
                     string roleStr = roles.Any() ? string.Join(", ", roles) : "User";
                     await _auditLogManager.LogAsync("Login", "User", user?.Id ?? "Unknown", $"User {Input.Email} logged in successfully.", "Success", Input.Email, roleStr);
-                    
+                    if (roles.Contains("Driver"))
+                    {
+                        return Redirect("/Driver/Dashboard");
+                    }
+
                     return LocalRedirect(returnUrl);
                 }
                 if (result.RequiresTwoFactor)

--- a/RentACar.Web/Controllers/BookingController.cs
+++ b/RentACar.Web/Controllers/BookingController.cs
@@ -14,6 +14,8 @@ using Microsoft.EntityFrameworkCore;
 using RentACar.Web.Models;
 using System.Security.Claims;
 using System.Linq;
+using Microsoft.Extensions.Options;
+using RentACar.Application.Services;
 
 namespace RentACar.Web.Controllers
 {
@@ -28,9 +30,12 @@ namespace RentACar.Web.Controllers
         private readonly CustomerManager _customerManager;
         private readonly PromocodeManager _promocodeManager;
         private readonly EmployeeManager _employeeManager;
+        private readonly DriverManager _driverManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IMapper _mapper;
         private readonly ILogger<BookingController> _logger;
+        private readonly AuditLogManager _auditLogManager;
+        private readonly DriverFeeOptions _driverFeeOptions;
 
         public BookingController(
             BookingManager bookingManager,
@@ -39,9 +44,12 @@ namespace RentACar.Web.Controllers
             CustomerManager customerManager,
             PromocodeManager promocodeManager,
             EmployeeManager employeeManager,
+            DriverManager driverManager,
             UserManager<IdentityUser> userManager,
             IMapper mapper,
-            ILogger<BookingController> logger)
+            ILogger<BookingController> logger,
+            AuditLogManager auditLogManager,
+            IOptions<DriverFeeOptions> driverFeeOptions)
         {
             _bookingManager = bookingManager;
             _paymentManager = paymentManager;
@@ -49,9 +57,12 @@ namespace RentACar.Web.Controllers
             _customerManager = customerManager;
             _promocodeManager = promocodeManager;
             _employeeManager = employeeManager;
+            _driverManager = driverManager;
             _userManager = userManager;
             _mapper = mapper;
             _logger = logger;
+            _auditLogManager = auditLogManager;
+            _driverFeeOptions = driverFeeOptions.Value;
         }
 
         [HttpGet("~/Booking")]
@@ -73,6 +84,9 @@ namespace RentACar.Web.Controllers
                 ViewBag.EndDate = end.ToDateTime(TimeOnly.MinValue).ToString("yyyy-MM-dd");
                 ViewBag.CarId = carId.Value.ToString();
             }
+
+            ViewBag.DriverFeeRate = _driverFeeOptions.Rate;
+            ViewBag.DriverFeeMode = _driverFeeOptions.Mode;
 
             return View("~/Views/ControlPanel/Booking/Add.cshtml", new BookingDto());
         }
@@ -138,6 +152,9 @@ namespace RentACar.Web.Controllers
             var promo = booking.PromocodeId.HasValue
                 ? await _promocodeManager.GetPromocodeByIdAsync(booking.PromocodeId.Value)
                 : null;
+            var driver = booking.DriverId.HasValue
+                ? (await _driverManager.GetAllDriversAsync()).FirstOrDefault(d => d.DriverId == booking.DriverId.Value)
+                : null;
 
             var viewModel = new BookingDetailsViewModel
             {
@@ -152,6 +169,13 @@ namespace RentACar.Web.Controllers
                 CustomerEmail = customer?.Email,
                 CustomerPhone = customer?.PhoneNumber,
                 EmployeeName = employee?.Name,
+                DriverName = driver?.DisplayName,
+                DriverPhone = driver?.PhoneNumber,
+                HasDriver = booking.HasDriver,
+                DriverFee = booking.DriverFee,
+                PickupAddress = booking.PickupAddress,
+                PickupLat = booking.PickupLat,
+                PickupLng = booking.PickupLng,
                 CarModel = car?.ModelName,
                 CarPlateNumber = car?.PlateNumber,
                 CarCategory = car?.CategoryName,
@@ -166,6 +190,67 @@ namespace RentACar.Web.Controllers
 
             return PartialView("~/Views/ControlPanel/Booking/_BookingDetailsPartial.cshtml", viewModel);
 
+        }
+
+        [HttpGet("~/Booking/{id}/AvailableDrivers")]
+        [Authorize(Roles = "Admin,Employee")]
+        public async Task<IActionResult> AvailableDrivers(int id)
+        {
+            var booking = await _bookingManager.GetBookingByIdAsync(id);
+            if (booking == null)
+            {
+                return NotFound();
+            }
+
+            var drivers = await _driverManager.GetAvailableDriversAsync(booking.Startdate, booking.Enddate);
+            var result = drivers.Select(d => new
+            {
+                driverId = d.DriverId,
+                name = d.DisplayName,
+                phone = d.PhoneNumber
+            });
+
+            return Ok(result);
+        }
+
+        [HttpPost("~/Booking/AssignDriver")]
+        [Authorize(Roles = "Admin,Employee")]
+        public async Task<IActionResult> AssignDriver([FromBody] AssignDriverRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var booking = await _bookingManager.GetBookingByIdAsync(request.BookingId);
+            if (booking == null)
+            {
+                return NotFound();
+            }
+
+            var availableDrivers = await _driverManager.GetAvailableDriversAsync(booking.Startdate, booking.Enddate);
+            if (request.DriverId.HasValue && !availableDrivers.Any(d => d.DriverId == request.DriverId.Value))
+            {
+                return BadRequest("Selected driver is not available for this booking timeframe.");
+            }
+
+            var editDto = _mapper.Map<BookingEditDto>(booking);
+            editDto.DriverId = request.DriverId;
+            editDto.BookingStatus = booking.BookingStatus ?? "Pending";
+
+            var updated = await _bookingManager.UpdateBookingAsync(editDto);
+            if (updated == null)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, "Unable to assign driver.");
+            }
+
+            var summary = request.DriverId.HasValue
+                ? $"Assigned driver {request.DriverId.Value} to booking {request.BookingId}."
+                : $"Unassigned driver from booking {request.BookingId}.";
+
+            await _auditLogManager.LogEventAsync("Booking.DriverAssignmentChanged", "Booking", request.BookingId.ToString(), summary, null, "Success");
+
+            return Ok(new { success = true });
         }
 
         [HttpGet]

--- a/RentACar.Web/Controllers/BookingsController.cs
+++ b/RentACar.Web/Controllers/BookingsController.cs
@@ -6,10 +6,12 @@ using RentACar.Application.Managers;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using System.Linq;
+using RentACar.Core.Repositories;
+using RentACar.Web.Models;
 
 namespace RentACar.Web.Controllers
 {
-    [Authorize(Roles = "Customer")]
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class BookingsController : Controller
@@ -18,6 +20,8 @@ namespace RentACar.Web.Controllers
         private readonly PaymentManager _paymentManager;
         private readonly CarManager _carManager;
         private readonly CustomerManager _customerManager;
+        private readonly DriverManager _driverManager;
+        private readonly IDriverLocationRepository _driverLocationRepository;
         private readonly UserManager<IdentityUser> _userManager;
 
         public BookingsController(
@@ -25,12 +29,16 @@ namespace RentACar.Web.Controllers
             PaymentManager paymentManager,
             CarManager carManager,
             CustomerManager customerManager,
+            DriverManager driverManager,
+            IDriverLocationRepository driverLocationRepository,
             UserManager<IdentityUser> userManager)
         {
             _bookingManager = bookingManager;
             _paymentManager = paymentManager;
             _carManager = carManager;
             _customerManager = customerManager;
+            _driverManager = driverManager;
+            _driverLocationRepository = driverLocationRepository;
             _userManager = userManager;
         }
 
@@ -43,6 +51,7 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpGet("~/Bookings/MyBookings")]
+        [Authorize(Roles = "Customer")]
         [ApiExplorerSettings(IgnoreApi = true)]
         public IActionResult MyBookings()
         {
@@ -50,6 +59,7 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpGet]
+        [Authorize(Roles = "Customer")]
         public async Task<IActionResult> Get()
         {
             var customerId = await GetCurrentCustomerId();
@@ -74,13 +84,16 @@ namespace RentACar.Web.Controllers
                     paymentStatus = latestPayment?.Status,
                     startdate = b.Startdate.ToString("yyyy-MM-dd"),
                     enddate = b.Enddate.ToString("yyyy-MM-dd"),
-                    totalPrice = b.TotalPrice
+                    totalPrice = b.TotalPrice,
+                    hasDriver = b.HasDriver,
+                    driverId = b.DriverId
                 });
             }
             return Ok(result);
         }
 
         [HttpPost("Pay")]
+        [Authorize(Roles = "Customer")]
         public async Task<IActionResult> Pay([FromBody] MakePaymentRequestDto request)
         {
             if (!ModelState.IsValid)
@@ -101,6 +114,7 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpGet("~/Bookings/Ticket/{id}")]
+        [Authorize(Roles = "Customer")]
         public async Task<IActionResult> Ticket(int id)
         {
             var customerId = await GetCurrentCustomerId();
@@ -119,6 +133,49 @@ namespace RentACar.Web.Controllers
 
             var bytes = GenerateTicketPdf(booking, car, payment);
             return File(bytes, "application/pdf", $"booking_{id}.pdf");
+        }
+
+        [HttpGet("~/Bookings/{id}/TrackDriver")]
+        [Authorize(Roles = "Customer,Admin,Employee")]
+        public async Task<IActionResult> TrackDriver(int id)
+        {
+            var booking = await _bookingManager.GetBookingByIdAsync(id);
+            if (booking == null)
+            {
+                return NotFound();
+            }
+
+            var userId = _userManager.GetUserId(User);
+            var isEmployee = User.IsInRole("Employee") || User.IsInRole("Admin");
+            if (!isEmployee)
+            {
+                var customer = await _customerManager.GetCustomerByAspNetUserId(userId);
+                if (customer == null || booking.CustomerId != customer.UserId)
+                {
+                    return Forbid();
+                }
+            }
+
+            var driver = booking.DriverId.HasValue
+                ? (await _driverManager.GetAllDriversAsync()).FirstOrDefault(d => d.DriverId == booking.DriverId.Value)
+                : null;
+            var location = await _driverLocationRepository.GetLatestByBookingIdAsync(booking.BookingId);
+
+            var viewModel = new TrackDriverViewModel
+            {
+                BookingId = booking.BookingId,
+                DriverName = driver?.DisplayName,
+                DriverPhone = driver?.PhoneNumber,
+                DriverLat = location?.Latitude,
+                DriverLng = location?.Longitude,
+                LastUpdatedUtc = location?.LastUpdatedUtc,
+                PickupAddress = booking.PickupAddress,
+                PickupLat = booking.PickupLat,
+                PickupLng = booking.PickupLng,
+                IsTrackingActive = location?.IsTrackingActive ?? false
+            };
+
+            return View("~/Views/Bookings/TrackDriver.cshtml", viewModel);
         }
 
         private byte[] GenerateTicketPdf(BookingDto booking, CarDto? car, PaymentDto? payment)

--- a/RentACar.Web/Controllers/DriversController.cs
+++ b/RentACar.Web/Controllers/DriversController.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using RentACar.Application.Managers;
+using RentACar.Web.Models.Driver;
+
+namespace RentACar.Web.Controllers;
+
+[Authorize(Roles = "Admin,Employee")]
+public class DriversController : Controller
+{
+    private readonly DriverManager _driverManager;
+    private readonly AuditLogManager _auditLogManager;
+
+    public DriversController(DriverManager driverManager, AuditLogManager auditLogManager)
+    {
+        _driverManager = driverManager;
+        _auditLogManager = auditLogManager;
+    }
+
+    [HttpGet("~/ControlPanel/Drivers")]
+    public async Task<IActionResult> Index()
+    {
+        var drivers = await _driverManager.GetAllDriversAsync();
+        return View("~/Views/ControlPanel/Drivers/Index.cshtml", drivers);
+    }
+
+    [HttpGet("~/ControlPanel/Drivers/Create")]
+    public IActionResult Create()
+    {
+        return View("~/Views/ControlPanel/Drivers/Create.cshtml", new DriverFormViewModel());
+    }
+
+    [HttpPost("~/ControlPanel/Drivers/Create")]
+    public async Task<IActionResult> Create(DriverFormViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View("~/Views/ControlPanel/Drivers/Create.cshtml", model);
+        }
+
+        var created = await _driverManager.CreateDriverAsync(model.AspNetUserId, model.DisplayName, model.PhoneNumber);
+        await _auditLogManager.LogEventAsync("Driver.Created", "Driver", created.DriverId.ToString(), $"Driver created for user {created.AspNetUserId}.", null, "Success");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpGet("~/ControlPanel/Drivers/Edit/{id:int}")]
+    public async Task<IActionResult> Edit(int id)
+    {
+        var drivers = await _driverManager.GetAllDriversAsync();
+        var driver = drivers.FirstOrDefault(d => d.DriverId == id);
+        if (driver == null)
+        {
+            return NotFound();
+        }
+
+        var model = new DriverFormViewModel
+        {
+            DriverId = driver.DriverId,
+            AspNetUserId = driver.AspNetUserId,
+            DisplayName = driver.DisplayName,
+            PhoneNumber = driver.PhoneNumber,
+            IsActive = driver.IsActive,
+            IsAvailableManual = driver.IsAvailableManual
+        };
+
+        return View("~/Views/ControlPanel/Drivers/Edit.cshtml", model);
+    }
+
+    [HttpPost("~/ControlPanel/Drivers/Edit")]
+    public async Task<IActionResult> Edit(DriverFormViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View("~/Views/ControlPanel/Drivers/Edit.cshtml", model);
+        }
+
+        var drivers = await _driverManager.GetAllDriversAsync();
+        var driver = drivers.FirstOrDefault(d => d.DriverId == model.DriverId);
+        if (driver == null)
+        {
+            return NotFound();
+        }
+
+        driver.DisplayName = model.DisplayName;
+        driver.PhoneNumber = model.PhoneNumber;
+        driver.IsActive = model.IsActive;
+        driver.IsAvailableManual = model.IsAvailableManual;
+
+        await _driverManager.UpdateDriverAsync(driver);
+        await _auditLogManager.LogEventAsync("Driver.Updated", "Driver", driver.DriverId.ToString(), $"Driver {driver.DriverId} updated.", null, "Success");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("~/ControlPanel/Drivers/Deactivate")]
+    public async Task<IActionResult> Deactivate(int id)
+    {
+        var drivers = await _driverManager.GetAllDriversAsync();
+        var driver = drivers.FirstOrDefault(d => d.DriverId == id);
+        if (driver == null)
+        {
+            return NotFound();
+        }
+
+        await _driverManager.DeactivateDriverAsync(driver);
+        await _auditLogManager.LogEventAsync("Driver.Deactivated", "Driver", driver.DriverId.ToString(), $"Driver {driver.DriverId} deactivated.", null, "Success");
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/RentACar.Web/Hubs/DriverTrackingHub.cs
+++ b/RentACar.Web/Hubs/DriverTrackingHub.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using RentACar.Application.Managers;
+using RentACar.Infrastructure.Data;
+
+namespace RentACar.Web.Hubs;
+
+[Authorize]
+public class DriverTrackingHub : Hub
+{
+    private readonly RentACarDbContext _dbContext;
+    private readonly IMemoryCache _memoryCache;
+    private readonly AuditLogManager _auditLogManager;
+
+    private static readonly TimeSpan MinUpdateInterval = TimeSpan.FromSeconds(4);
+
+    public DriverTrackingHub(RentACarDbContext dbContext, IMemoryCache memoryCache, AuditLogManager auditLogManager)
+    {
+        _dbContext = dbContext;
+        _memoryCache = memoryCache;
+        _auditLogManager = auditLogManager;
+    }
+
+    public async Task JoinBookingTracking(int bookingId)
+    {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new HubException("Unauthorized");
+        }
+
+        var booking = await _dbContext.Bookings
+            .Include(b => b.Customer)
+            .FirstOrDefaultAsync(b => b.BookingId == bookingId);
+
+        if (booking == null)
+        {
+            throw new HubException("Booking not found");
+        }
+
+        var isEmployee = Context.User?.IsInRole("Employee") == true || Context.User?.IsInRole("Admin") == true;
+        var isOwner = booking.Customer?.aspNetUserId == userId;
+
+        if (!isEmployee && !isOwner)
+        {
+            throw new HubException("Not authorized to track this booking");
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"booking-{bookingId}");
+    }
+
+    public async Task SendLocationUpdate(int bookingId, decimal lat, decimal lng)
+    {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new HubException("Unauthorized");
+        }
+
+        var booking = await _dbContext.Bookings
+            .Include(b => b.Driver)
+            .FirstOrDefaultAsync(b => b.BookingId == bookingId);
+
+        if (booking?.Driver == null || booking.Driver.AspNetUserId != userId)
+        {
+            await _auditLogManager.LogEventAsync("DriverTracking.UnauthorizedUpdate", "Booking", bookingId.ToString(), "Unauthorized driver location update attempt.", null, "Failed");
+            throw new HubException("Not authorized to update this booking");
+        }
+
+        var cacheKey = $"tracking-update-{bookingId}";
+        if (_memoryCache.TryGetValue<DateTime>(cacheKey, out var lastUpdate) &&
+            DateTime.UtcNow - lastUpdate < MinUpdateInterval)
+        {
+            return;
+        }
+
+        _memoryCache.Set(cacheKey, DateTime.UtcNow, MinUpdateInterval);
+
+        var location = await _dbContext.DriverLocations
+            .FirstOrDefaultAsync(l => l.BookingId == bookingId && l.DriverId == booking.Driver.DriverId);
+
+        if (location == null)
+        {
+            location = new Core.Entities.DriverLocation
+            {
+                BookingId = bookingId,
+                DriverId = booking.Driver.DriverId,
+                Latitude = lat,
+                Longitude = lng,
+                LastUpdatedUtc = DateTime.UtcNow,
+                IsTrackingActive = true
+            };
+            _dbContext.DriverLocations.Add(location);
+        }
+        else
+        {
+            location.Latitude = lat;
+            location.Longitude = lng;
+            location.LastUpdatedUtc = DateTime.UtcNow;
+            location.IsTrackingActive = true;
+            _dbContext.DriverLocations.Update(location);
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        await Clients.Group($"booking-{bookingId}")
+            .SendAsync("ReceiveLocationUpdate", new
+            {
+                bookingId,
+                lat,
+                lng,
+                timestamp = location.LastUpdatedUtc
+            });
+    }
+}

--- a/RentACar.Web/Models/AssignDriverRequest.cs
+++ b/RentACar.Web/Models/AssignDriverRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Web.Models;
+
+public class AssignDriverRequest
+{
+    [Required]
+    public int BookingId { get; set; }
+
+    public int? DriverId { get; set; }
+}

--- a/RentACar.Web/Models/BookingDetailsViewModel.cs
+++ b/RentACar.Web/Models/BookingDetailsViewModel.cs
@@ -15,6 +15,13 @@ namespace RentACar.Web.Models
         public string? CustomerEmail { get; set; }
         public string? CustomerPhone { get; set; }
         public string? EmployeeName { get; set; }
+        public string? DriverName { get; set; }
+        public string? DriverPhone { get; set; }
+        public bool HasDriver { get; set; }
+        public decimal? DriverFee { get; set; }
+        public string? PickupAddress { get; set; }
+        public decimal? PickupLat { get; set; }
+        public decimal? PickupLng { get; set; }
         public string? CarModel { get; set; }
         public string? CarPlateNumber { get; set; }
         public string? CarCategory { get; set; }

--- a/RentACar.Web/Models/Driver/DriverAvailabilityBlockViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverAvailabilityBlockViewModel.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverAvailabilityBlockViewModel
+{
+    public int DriverAvailabilityId { get; set; }
+
+    [Required]
+    public DateTime StartTime { get; set; }
+
+    [Required]
+    public DateTime EndTime { get; set; }
+
+    public bool IsRecurringWeekly { get; set; }
+}

--- a/RentACar.Web/Models/Driver/DriverBookingDetailsViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverBookingDetailsViewModel.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverBookingDetailsViewModel
+{
+    public int BookingId { get; set; }
+    public string? BookingStatus { get; set; }
+    public DateOnly StartDate { get; set; }
+    public DateOnly EndDate { get; set; }
+    public string? CustomerName { get; set; }
+    public string? CustomerEmail { get; set; }
+    public string? CustomerPhone { get; set; }
+    public string? CarModel { get; set; }
+    public string? CarPlateNumber { get; set; }
+    public string? PickupAddress { get; set; }
+    public decimal? PickupLat { get; set; }
+    public decimal? PickupLng { get; set; }
+    public bool IsTrackingActive { get; set; }
+    public DateTime? LastTrackingUpdateUtc { get; set; }
+}

--- a/RentACar.Web/Models/Driver/DriverBookingListItemViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverBookingListItemViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverBookingListItemViewModel
+{
+    public int BookingId { get; set; }
+    public string? CustomerName { get; set; }
+    public string? CarModel { get; set; }
+    public DateOnly StartDate { get; set; }
+    public DateOnly EndDate { get; set; }
+    public string? Status { get; set; }
+    public string? PickupAddress { get; set; }
+}

--- a/RentACar.Web/Models/Driver/DriverCalendarViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverCalendarViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverCalendarViewModel
+{
+    public DateTime Month { get; set; }
+    public List<DriverBookingListItemViewModel> Bookings { get; set; } = new();
+    public List<DriverAvailabilityBlockViewModel> AvailabilityBlocks { get; set; } = new();
+}

--- a/RentACar.Web/Models/Driver/DriverDashboardViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverDashboardViewModel.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverDashboardViewModel
+{
+    public string? DriverName { get; set; }
+    public bool IsAvailableManual { get; set; }
+    public bool IsOnTrip { get; set; }
+    public List<DriverBookingListItemViewModel> TodayBookings { get; set; } = new();
+    public List<DriverBookingListItemViewModel> UpcomingBookings { get; set; } = new();
+}

--- a/RentACar.Web/Models/Driver/DriverFormViewModel.cs
+++ b/RentACar.Web/Models/Driver/DriverFormViewModel.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RentACar.Web.Models.Driver;
+
+public class DriverFormViewModel
+{
+    public int? DriverId { get; set; }
+
+    [Required]
+    public string AspNetUserId { get; set; } = string.Empty;
+
+    [Required]
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? PhoneNumber { get; set; }
+
+    public bool IsActive { get; set; }
+    public bool IsAvailableManual { get; set; }
+}

--- a/RentACar.Web/Models/TrackDriverViewModel.cs
+++ b/RentACar.Web/Models/TrackDriverViewModel.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace RentACar.Web.Models;
+
+public class TrackDriverViewModel
+{
+    public int BookingId { get; set; }
+    public string? DriverName { get; set; }
+    public string? DriverPhone { get; set; }
+    public decimal? DriverLat { get; set; }
+    public decimal? DriverLng { get; set; }
+    public DateTime? LastUpdatedUtc { get; set; }
+    public string? PickupAddress { get; set; }
+    public decimal? PickupLat { get; set; }
+    public decimal? PickupLng { get; set; }
+    public bool IsTrackingActive { get; set; }
+}

--- a/RentACar.Web/Program.cs
+++ b/RentACar.Web/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddMemoryCache();
+builder.Services.AddSignalR();
 
 // ✅ Register repositories
 builder.Services.AddScoped<IBookingRepository, BookingRepository>();
@@ -73,6 +74,9 @@ builder.Services.AddScoped<IBlacklistRepository, BlacklistRepository>();
 builder.Services.AddScoped<IPromocodeRepository, PromocodeRepository>();
 builder.Services.AddScoped<IPaymentMethodRepository, PaymentMethodRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
+builder.Services.AddScoped<IDriverRepository, DriverRepository>();
+builder.Services.AddScoped<IDriverAvailabilityRepository, DriverAvailabilityRepository>();
+builder.Services.AddScoped<IDriverLocationRepository, DriverLocationRepository>();
 builder.Services.AddHttpClient<IEmailService, MailjetEmailService>();
 builder.Services.AddHttpClient<RentACar.Application.Services.IStripePaymentService, RentACar.Application.Services.StripePaymentService>(client =>
 {
@@ -93,6 +97,8 @@ builder.Services.AddScoped<BookingManager>();
 builder.Services.AddScoped<PaymentManager>();
 builder.Services.AddScoped<EmailManager>();
 builder.Services.AddScoped<AuditLogManager>();
+builder.Services.AddScoped<DriverManager>();
+builder.Services.Configure<DriverFeeOptions>(builder.Configuration.GetSection(DriverFeeOptions.SectionName));
 
 // // ✅ HTTPS redirection
 // builder.Services.AddHttpsRedirection(options =>
@@ -129,6 +135,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapHub<RentACar.Web.Hubs.DriverTrackingHub>("/hubs/driver-tracking");
 
 app.MapControllerRoute(
     name: "default",

--- a/RentACar.Web/Views/Bookings/MyBookings.cshtml
+++ b/RentACar.Web/Views/Bookings/MyBookings.cshtml
@@ -16,6 +16,7 @@
                         <th>Start</th>
                         <th>End</th>
                         <th>Price</th>
+                        <th>Driver</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -104,6 +105,7 @@
                     `<td>${b.startdate}</td>` +
                     `<td>${b.enddate}</td>` +
                     `<td>${Number(b.totalPrice ?? 0).toFixed(2)}</td>` +
+                    `<td>${b.hasDriver ? 'Assigned' : 'Self-drive'}</td>` +
                     `<td>
                                 ${showPayButton ? `
                                     <button class="btn btn-primary btn-sm me-2 pay-btn"
@@ -112,6 +114,12 @@
                                             ${payDisabled ? 'disabled' : ''}>
                                         Pay
                                     </button>
+                                ` : ''}
+                                ${b.hasDriver ? `
+                                    <a class="btn btn-warning btn-sm me-2"
+                                       href="/Bookings/${b.bookingId}/TrackDriver">
+                                        Track Driver
+                                    </a>
                                 ` : ''}
                                 <a class="btn btn-secondary btn-sm"
                                    href="/Bookings/Ticket/${b.bookingId}"

--- a/RentACar.Web/Views/Bookings/TrackDriver.cshtml
+++ b/RentACar.Web/Views/Bookings/TrackDriver.cshtml
@@ -1,0 +1,110 @@
+@inject IConfiguration Configuration
+@model RentACar.Web.Models.TrackDriverViewModel
+@{
+    ViewData["Title"] = "Track Driver";
+    var mapsKey = Configuration["GoogleMaps:ApiKey"] ?? string.Empty;
+}
+
+<div class="container py-5">
+    <div class="card bg-dark text-white border-0 shadow-lg p-4">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <div>
+                <h3 class="mb-1">Track Your Driver</h3>
+                <p class="text-muted mb-0">Booking #@Model.BookingId</p>
+            </div>
+            <div>
+                <span class="badge @(Model.IsTrackingActive ? "bg-success" : "bg-secondary")">
+                    @(Model.IsTrackingActive ? "Live Tracking ON" : "Tracking Off")
+                </span>
+            </div>
+        </div>
+
+        <div class="row g-4">
+            <div class="col-lg-4">
+                <div class="p-3 bg-black rounded-3">
+                    <h5>@Model.DriverName</h5>
+                    <p class="text-muted mb-1">@Model.DriverPhone</p>
+                    <small class="text-muted d-block">Last update: <span id="lastUpdate">@Model.LastUpdatedUtc?.ToString("HH:mm:ss") ?? "N/A"</span></small>
+                    <hr class="border-secondary" />
+                    <p class="mb-0">Pickup: @Model.PickupAddress</p>
+                </div>
+            </div>
+            <div class="col-lg-8">
+                <div id="trackingMap" style="height: 420px; border-radius: 16px;"></div>
+                <div class="mt-3 text-muted" id="trackingStatus">
+                    @(Model.IsTrackingActive ? "Receiving live updates..." : "Tracking is currently off.")
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=@mapsKey&callback=initTrackingMap"></script>
+    <script>
+        let trackingMap;
+        let driverMarker;
+        let pickupMarker;
+        const bookingId = @Model.BookingId;
+
+        function initTrackingMap() {
+            const pickupLat = Number('@Model.PickupLat');
+            const pickupLng = Number('@Model.PickupLng');
+            const initialLat = Number('@Model.DriverLat');
+            const initialLng = Number('@Model.DriverLng');
+            const center = initialLat && initialLng ? { lat: initialLat, lng: initialLng } : { lat: pickupLat || 25.2048, lng: pickupLng || 55.2708 };
+
+            trackingMap = new google.maps.Map(document.getElementById('trackingMap'), {
+                center,
+                zoom: 13,
+                styles: [
+                    { elementType: 'geometry', stylers: [{ color: '#1f1f1f' }] },
+                    { elementType: 'labels.text.fill', stylers: [{ color: '#f5f5f5' }] }
+                ]
+            });
+
+            if (pickupLat && pickupLng) {
+                pickupMarker = new google.maps.Marker({
+                    position: { lat: pickupLat, lng: pickupLng },
+                    map: trackingMap,
+                    icon: { url: "https://maps.google.com/mapfiles/ms/icons/yellow-dot.png" },
+                    title: 'Pickup'
+                });
+            }
+
+            if (initialLat && initialLng) {
+                driverMarker = new google.maps.Marker({
+                    position: { lat: initialLat, lng: initialLng },
+                    map: trackingMap,
+                    title: 'Driver'
+                });
+            }
+        }
+
+        const connection = new signalR.HubConnectionBuilder()
+            .withUrl('/hubs/driver-tracking')
+            .withAutomaticReconnect()
+            .build();
+
+        connection.on('ReceiveLocationUpdate', payload => {
+            const { lat, lng, timestamp } = payload;
+            const position = { lat, lng };
+            if (!driverMarker) {
+                driverMarker = new google.maps.Marker({ position, map: trackingMap, title: 'Driver' });
+            } else {
+                driverMarker.setPosition(position);
+            }
+            trackingMap.setCenter(position);
+            document.getElementById('lastUpdate').textContent = new Date(timestamp).toLocaleTimeString();
+            document.getElementById('trackingStatus').textContent = 'Receiving live updates...';
+        });
+
+        async function startTracking() {
+            await connection.start();
+            await connection.invoke('JoinBookingTracking', bookingId);
+        }
+
+        startTracking();
+    </script>
+}

--- a/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
@@ -1,6 +1,7 @@
 ﻿@inject UserManager<IdentityUser> UserManager
 @inject SignInManager<IdentityUser> SignInManager
 @inject PaymentMethodManager PaymentMethodManager
+@inject IConfiguration Configuration
 
 @using Microsoft.AspNetCore.Identity
 @using RentACar.Application.Managers
@@ -19,6 +20,9 @@
     var startValue = ViewBag.StartDate ?? DateTime.Today.ToString("yyyy-MM-dd");
     var endValue = ViewBag.EndDate ?? DateTime.Today.AddDays(1).ToString("yyyy-MM-dd");
     var backUrl = isCustomer ? "/Bookings/MyBookings" : "/Booking";
+    var mapsKey = Configuration["GoogleMaps:ApiKey"] ?? string.Empty;
+    var driverFeeRate = ViewBag.DriverFeeRate ?? 0;
+    var driverFeeMode = ViewBag.DriverFeeMode ?? "PerDay";
 
 }
 
@@ -69,6 +73,37 @@
             var methods = await PaymentMethodManager.GetAllActivePaymentMethodsAsync();
             }
             <div class="mb-3">
+                <label class="form-label">Driver Option</label>
+                <div class="d-flex gap-3">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="HasDriver" id="HasDriverFalse" value="false" checked />
+                        <label class="form-check-label" for="HasDriverFalse">Without Driver (Self-drive)</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="HasDriver" id="HasDriverTrue" value="true" />
+                        <label class="form-check-label" for="HasDriverTrue">With Driver</label>
+                    </div>
+                </div>
+                <div class="form-text text-muted mt-1">
+                    Driver fee: <strong id="driverFeeLabel">@driverFeeRate</strong> (@driverFeeMode)
+                </div>
+            </div>
+            <div class="mb-3" id="pickupDetailsSection" style="display:none;">
+                <label class="form-label">Pickup Address</label>
+                <input type="text" id="PickupAddress" class="form-control" placeholder="Enter pickup address" />
+                <input type="hidden" id="PickupLat" />
+                <input type="hidden" id="PickupLng" />
+                <div class="mt-3">
+                    <div id="pickupMap" style="height: 280px; border-radius: 12px;"></div>
+                    <small class="text-muted d-block mt-2">Click on the map to set pickup location.</small>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="alert alert-secondary">
+                    Estimated Driver Fee: <strong id="driverFeeValue">0.00</strong>
+                </div>
+            </div>
+            <div class="mb-3">
                 <p>Found @methods.Count payment methods.</p>
 
                 <label class="form-label">Payment Method</label>
@@ -93,21 +128,76 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script>
+        const driverFeeRate = Number('@driverFeeRate');
+        const driverFeeMode = '@driverFeeMode';
+        const hasDriverInputs = document.querySelectorAll('input[name="HasDriver"]');
+        const pickupSection = document.getElementById('pickupDetailsSection');
+        const driverFeeLabel = document.getElementById('driverFeeLabel');
+        const driverFeeValue = document.getElementById('driverFeeValue');
+
+        function updateDriverSection() {
+            const selected = document.querySelector('input[name="HasDriver"]:checked');
+            const isWithDriver = selected && selected.value === 'true';
+            pickupSection.style.display = isWithDriver ? 'block' : 'none';
+            if (!isWithDriver) {
+                document.getElementById('PickupLat').value = '';
+                document.getElementById('PickupLng').value = '';
+            }
+            updateDriverFee();
+        }
+
+        function updateDriverFee() {
+            const isWithDriver = document.querySelector('input[name="HasDriver"]:checked')?.value === 'true';
+            if (!isWithDriver) {
+                driverFeeValue.textContent = '0.00';
+                return;
+            }
+
+            const start = new Date(document.getElementById('Startdate').value);
+            const end = new Date(document.getElementById('Enddate').value);
+            const diffDays = Math.max(1, Math.ceil((end - start) / (1000 * 60 * 60 * 24)));
+            let fee = driverFeeRate;
+
+            if (driverFeeMode === 'PerDay') {
+                fee = driverFeeRate * diffDays;
+            }
+
+            driverFeeValue.textContent = fee.toFixed(2);
+        }
+
+        driverFeeLabel.textContent = `${driverFeeRate}`;
+        hasDriverInputs.forEach(input => input.addEventListener('change', updateDriverSection));
+        document.getElementById('Startdate').addEventListener('change', updateDriverFee);
+        document.getElementById('Enddate').addEventListener('change', updateDriverFee);
+        updateDriverSection();
+
         document.getElementById('bookingForm').addEventListener('submit', async function (e) {
             e.preventDefault();
 
             const form = e.target;
             const customerIdInput = document.getElementById('CustomerId');
+            const hasDriver = document.querySelector('input[name="HasDriver"]:checked')?.value === 'true';
+            const pickupLat = document.getElementById('PickupLat').value;
+            const pickupLng = document.getElementById('PickupLng').value;
             const data = {
                 carId: parseInt(document.getElementById('CarId').value),
                 startdate: document.getElementById('Startdate').value,
                 enddate: document.getElementById('Enddate').value,
                 paymentMethodId: parseInt(document.getElementById('paymentMethod').value),
                 promocode: document.getElementById('promocode').value || null,
+                hasDriver: hasDriver,
+                pickupAddress: document.getElementById('PickupAddress').value || null,
+                pickupLat: pickupLat ? parseFloat(pickupLat) : null,
+                pickupLng: pickupLng ? parseFloat(pickupLng) : null
             };
 
             if (customerIdInput) {
                 data.customerId = parseInt(customerIdInput.value);
+            }
+
+            if (hasDriver && (!data.pickupLat || !data.pickupLng)) {
+                showPopup('Please select a pickup location on the map.', 'error');
+                return;
             }
 
             try {
@@ -137,6 +227,38 @@
             }
         });
 
+    </script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=@mapsKey&callback=initPickupMap"></script>
+    <script>
+        let pickupMap;
+        let pickupMarker;
+        function initPickupMap() {
+            const defaultCenter = { lat: 25.2048, lng: 55.2708 };
+            pickupMap = new google.maps.Map(document.getElementById('pickupMap'), {
+                center: defaultCenter,
+                zoom: 10,
+                styles: [
+                    { elementType: 'geometry', stylers: [{ color: '#1f1f1f' }] },
+                    { elementType: 'labels.text.stroke', stylers: [{ color: '#1f1f1f' }] },
+                    { elementType: 'labels.text.fill', stylers: [{ color: '#f5f5f5' }] }
+                ]
+            });
+
+            pickupMap.addListener('click', (event) => {
+                const lat = event.latLng.lat();
+                const lng = event.latLng.lng();
+                document.getElementById('PickupLat').value = lat.toFixed(6);
+                document.getElementById('PickupLng').value = lng.toFixed(6);
+                if (!pickupMarker) {
+                    pickupMarker = new google.maps.Marker({
+                        position: { lat, lng },
+                        map: pickupMap
+                    });
+                } else {
+                    pickupMarker.setPosition({ lat, lng });
+                }
+            });
+        }
     </script>
 </body>
 </html>

--- a/RentACar.Web/Views/ControlPanel/Booking/_BookingDetailsPartial.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Booking/_BookingDetailsPartial.cshtml
@@ -78,6 +78,15 @@
                             <dt class="col-sm-5">Booked By</dt>
                             <dd class="col-sm-7">@(!string.IsNullOrWhiteSpace(Model.EmployeeName) ? Model.EmployeeName : "-")</dd>
 
+                            <dt class="col-sm-5">Driver Option</dt>
+                            <dd class="col-sm-7">@((Model.HasDriver ? "With Driver" : "Self-drive"))</dd>
+
+                            <dt class="col-sm-5">Driver Fee</dt>
+                            <dd class="col-sm-7">@((Model.DriverFee?.ToString("C") ?? "-"))</dd>
+
+                            <dt class="col-sm-5">Pickup</dt>
+                            <dd class="col-sm-7">@(!string.IsNullOrWhiteSpace(Model.PickupAddress) ? Model.PickupAddress : "-")</dd>
+
                             <dt class="col-sm-5">Payment</dt>
                             <dd class="col-sm-7">@((Model.PaymentId.HasValue ? $"#{Model.PaymentId}" : "-"))</dd>
 
@@ -90,6 +99,21 @@
                             <dt class="col-sm-5">Discount</dt>
                             <dd class="col-sm-7">@((Model.PromocodeDiscount.HasValue ? $"{Model.PromocodeDiscount.Value}%" : "-"))</dd>
                         </dl>
+                    </div>
+
+                    <div class="col-md-12">
+                        <h6 class="text-uppercase text-secondary mt-3">Assign Driver</h6>
+                        <div class="bg-dark border rounded p-3">
+                            <p class="mb-2 text-muted">Current Driver: <strong>@(!string.IsNullOrWhiteSpace(Model.DriverName) ? Model.DriverName : "Unassigned")</strong></p>
+                            <div class="d-flex gap-2 align-items-center">
+                                <select id="driverSelect" class="form-select">
+                                    <option value="">Select available driver</option>
+                                </select>
+                                <button class="btn btn-primary" type="button" id="assignDriverBtn">Assign</button>
+                                <button class="btn btn-outline-light" type="button" id="unassignDriverBtn">Unassign</button>
+                            </div>
+                            <small class="text-muted d-block mt-2">Only drivers available for the booking timeframe are listed.</small>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -106,5 +130,52 @@
         const modalElement = document.getElementById('bookingDetailsModal');
         modalElement.addEventListener('hidden.bs.modal', () => modalElement.remove(), { once: true });
         new bootstrap.Modal(modalElement).show();
+
+        const bookingId = @Model.BookingId;
+        const driverSelect = document.getElementById('driverSelect');
+        const assignButton = document.getElementById('assignDriverBtn');
+        const unassignButton = document.getElementById('unassignDriverBtn');
+
+        async function loadAvailableDrivers() {
+            const res = await fetch(`/Booking/${bookingId}/AvailableDrivers`);
+            if (!res.ok) {
+                return;
+            }
+            const drivers = await res.json();
+            driverSelect.innerHTML = '<option value="">Select available driver</option>';
+            drivers.forEach(driver => {
+                const option = document.createElement('option');
+                option.value = driver.driverId;
+                option.textContent = `${driver.name} (${driver.phone || 'No phone'})`;
+                driverSelect.appendChild(option);
+            });
+        }
+
+        async function assignDriver(driverId) {
+            const res = await fetch('/Booking/AssignDriver', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ bookingId, driverId })
+            });
+
+            if (!res.ok) {
+                const msg = await res.text();
+                alert(msg || 'Unable to assign driver.');
+                return;
+            }
+
+            location.reload();
+        }
+
+        assignButton.addEventListener('click', () => {
+            if (!driverSelect.value) {
+                alert('Select a driver to assign.');
+                return;
+            }
+            assignDriver(Number(driverSelect.value));
+        });
+
+        unassignButton.addEventListener('click', () => assignDriver(null));
+        loadAvailableDrivers();
     })();
 </script>

--- a/RentACar.Web/Views/ControlPanel/ChangeRole.cshtml
+++ b/RentACar.Web/Views/ControlPanel/ChangeRole.cshtml
@@ -48,6 +48,10 @@
                         <input class="form-check-input" type="radio" asp-for="Role" value="Employee" id="roleEmployee" />
                         <label class="form-check-label" for="roleEmployee" style="color:white">Employee</label>
                     </div>
+                    <div class="form-check form-check-inline ">
+                        <input class="form-check-input" type="radio" asp-for="Role" value="Driver" id="roleDriver" />
+                        <label class="form-check-label" for="roleDriver" style="color:white">Driver</label>
+                    </div>
                     <br />
                     <span asp-validation-for="Role" class="text-danger"></span>
                 </div>

--- a/RentACar.Web/Views/ControlPanel/Drivers/Create.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Drivers/Create.cshtml
@@ -1,0 +1,40 @@
+@model RentACar.Web.Models.Driver.DriverFormViewModel
+@{
+    ViewData["Title"] = "Create Driver";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body class="bg-dark text-white">
+    <div class="container py-4">
+        <a href="/ControlPanel/Drivers" class="btn btn-outline-warning mb-3">Back</a>
+        <h2>Create Driver</h2>
+        <form method="post" action="/ControlPanel/Drivers/Create" class="mt-3">
+            <div class="mb-3">
+                <label class="form-label">AspNet User ID</label>
+                <input asp-for="AspNetUserId" class="form-control" />
+                <span asp-validation-for="AspNetUserId" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Display Name</label>
+                <input asp-for="DisplayName" class="form-control" />
+                <span asp-validation-for="DisplayName" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Phone</label>
+                <input asp-for="PhoneNumber" class="form-control" />
+            </div>
+            <button type="submit" class="btn btn-warning">Create</button>
+        </form>
+    </div>
+
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Drivers/Edit.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Drivers/Edit.cshtml
@@ -1,0 +1,48 @@
+@model RentACar.Web.Models.Driver.DriverFormViewModel
+@{
+    ViewData["Title"] = "Edit Driver";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body class="bg-dark text-white">
+    <div class="container py-4">
+        <a href="/ControlPanel/Drivers" class="btn btn-outline-warning mb-3">Back</a>
+        <h2>Edit Driver</h2>
+        <form method="post" action="/ControlPanel/Drivers/Edit" class="mt-3">
+            <input type="hidden" asp-for="DriverId" />
+            <div class="mb-3">
+                <label class="form-label">AspNet User ID</label>
+                <input asp-for="AspNetUserId" class="form-control" readonly />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Display Name</label>
+                <input asp-for="DisplayName" class="form-control" />
+                <span asp-validation-for="DisplayName" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Phone</label>
+                <input asp-for="PhoneNumber" class="form-control" />
+            </div>
+            <div class="form-check mb-2">
+                <input asp-for="IsActive" class="form-check-input" />
+                <label asp-for="IsActive" class="form-check-label">Active</label>
+            </div>
+            <div class="form-check mb-3">
+                <input asp-for="IsAvailableManual" class="form-check-input" />
+                <label asp-for="IsAvailableManual" class="form-check-label">Manual Availability</label>
+            </div>
+            <button type="submit" class="btn btn-warning">Save Changes</button>
+        </form>
+    </div>
+
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Drivers/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Drivers/Index.cshtml
@@ -1,0 +1,59 @@
+@model List<RentACar.Core.Entities.Driver>
+@{
+    ViewData["Title"] = "Drivers";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body class="bg-dark text-white">
+    <div class="container py-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2>Drivers Management</h2>
+            <a class="btn btn-warning" href="/ControlPanel/Drivers/Create">Add Driver</a>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-dark table-hover align-middle">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Phone</th>
+                        <th>Status</th>
+                        <th>Manual Availability</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var driver in Model)
+                    {
+                        <tr>
+                            <td>@driver.DriverId</td>
+                            <td>@driver.DisplayName</td>
+                            <td>@driver.PhoneNumber</td>
+                            <td>@(driver.IsActive ? "Active" : "Inactive")</td>
+                            <td>@(driver.IsAvailableManual ? "Available" : "Unavailable")</td>
+                            <td class="text-end">
+                                <a class="btn btn-sm btn-outline-light" href="/ControlPanel/Drivers/Edit/@driver.DriverId">Edit</a>
+                                <form method="post" action="/ControlPanel/Drivers/Deactivate" class="d-inline">
+                                    <input type="hidden" name="id" value="@driver.DriverId" />
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Deactivate</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/RentACar.Web/Views/ControlPanel/Index.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Index.cshtml
@@ -30,6 +30,10 @@
                 <i class="fas fa-user-tie"></i>
                 <div>Employees</div>
             </a>
+            <a asp-controller="Drivers" asp-action="Index" class="panel-action">
+                <i class="fas fa-shuttle-van"></i>
+                <div>Drivers</div>
+            </a>
             @if (User.IsInRole("Admin"))
             {
                 <a href="/ControlPanel/ChangeRole" class="panel-action">

--- a/RentACar.Web/Views/Shared/_Sidebar.cshtml
+++ b/RentACar.Web/Views/Shared/_Sidebar.cshtml
@@ -80,6 +80,10 @@
                             <span class="material-symbols-outlined text-[18px]">badge</span>
                             <span>Employees</span>
                         </a>
+                        <a href="/ControlPanel/Drivers" class="sidebar-sublink">
+                            <span class="material-symbols-outlined text-[18px]">drive_eta</span>
+                            <span>Drivers</span>
+                        </a>
                         <a href="/Payment" class="sidebar-sublink">
                             <span class="material-symbols-outlined text-[18px]">payments</span>
                             <span>Financials</span>

--- a/RentACar.Web/appsettings.Development.json
+++ b/RentACar.Web/appsettings.Development.json
@@ -29,5 +29,12 @@
     "Properties": {
       "Application": "RentACar.Web (Development)"
     }
+  },
+  "DriverFee": {
+    "Mode": "PerDay",
+    "Rate": 85
+  },
+  "GoogleMaps": {
+    "ApiKey": ""
   }
 }

--- a/RentACar.Web/appsettings.json
+++ b/RentACar.Web/appsettings.json
@@ -33,5 +33,12 @@
       "Application": "RentACar.Web"
     }
   },
+  "DriverFee": {
+    "Mode": "PerDay",
+    "Rate": 85
+  },
+  "GoogleMaps": {
+    "ApiKey": ""
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
### Motivation
- Add an end-to-end Driver role and real-time tracking so drivers can manage availability/bookings and customers can track drivers live. 

### Description
- Database & domain: added `Driver`, `DriverAvailability`, and `DriverLocation` entities and extended `Booking` with `HasDriver`, `DriverId`, `PickupAddress`, `PickupLat`, `PickupLng`, and `DriverFee`, and registered them in `RentACarDbContext` with migrations-ready configuration. 
- Repositories & managers: added `IDriver*` repositories and implementations plus `DriverManager` and `DriverFeeOptions` to encapsulate availability, selection and fee calculation logic, and extended `BookingManager` to support driver selection, driver-fee calculation and availability validation. 
- Controllers & Views: implemented a dedicated Driver area with layout and pages (`/Driver/Dashboard`, `/Driver/Bookings`, `/Driver/Calendar`, `/Driver/Availability`) and control-panel pages for driver CRUD and assignment under `ControlPanel/Drivers`; updated booking UI (`/Booking/Add`) to offer `With Driver/Without Driver`, pickup pin picker and driver fee estimate, and added customer tracking page (`/Bookings/{id}/TrackDriver`). 
- Real-time tracking & maps: added `DriverTrackingHub` (SignalR) to accept driver location updates (throttled) and broadcast to booking subscribers, integrated Google Maps (API key read from config `GoogleMaps:ApiKey`) for pickup selection and tracking pages, and wired hub at `/hubs/driver-tracking`. 
- Security & audit: enforced role-based access (`[Authorize(Roles="Driver")]`, control panel restrictions), driver-only publish rules in the hub, login redirect for users in `Driver` role to `/Driver/Dashboard`, and audit logging for driver lifecycle and tracking events. 
- DI & config: registered new repositories/managers/hub and added `DriverFee` configuration (`DriverFee:Mode/Rate`) in `appsettings` and development config. 

### Testing
- Automated tests: none executed in this rollout (no unit/integration tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697282af0ca48320aaa5862dec2e5b9d)