### PR TITLE
Fix email composer: template population, attachments, distribution lists, drafts and toolbar

### DIFF
--- a/RentACar.Application/Managers/EmailDraftManager.cs
+++ b/RentACar.Application/Managers/EmailDraftManager.cs
@@ -91,5 +91,10 @@ namespace RentACar.Application.Managers
                 await _draftRepository.DeleteAsync(draft);
             }
         }
+
+        public async Task DeleteAllDraftsAsync(string userId)
+        {
+            await _draftRepository.DeleteDraftsByUserIdAsync(userId);
+        }
     }
 }

--- a/RentACar.Core/Repositories/IEmailDraftRepository.cs
+++ b/RentACar.Core/Repositories/IEmailDraftRepository.cs
@@ -9,5 +9,6 @@ namespace RentACar.Core.Repositories
     {
         Task<IEnumerable<EmailDraft>> GetDraftsByUserIdAsync(string userId);
         Task<EmailDraft> GetDraftByIdAndUserIdAsync(int id, string userId);
+        Task DeleteDraftsByUserIdAsync(string userId);
     }
 }

--- a/RentACar.Infrastructure/Repositories/EmailDraftRepository.cs
+++ b/RentACar.Infrastructure/Repositories/EmailDraftRepository.cs
@@ -28,5 +28,20 @@ namespace RentACar.Infrastructure.Repositories
             return await _dbContext.EmailDrafts
                 .FirstOrDefaultAsync(d => d.Id == id && d.CreatedByUserId == userId);
         }
+
+        public async Task DeleteDraftsByUserIdAsync(string userId)
+        {
+            var drafts = await _dbContext.EmailDrafts
+                .Where(d => d.CreatedByUserId == userId)
+                .ToListAsync();
+
+            if (drafts.Count == 0)
+            {
+                return;
+            }
+
+            _dbContext.EmailDrafts.RemoveRange(drafts);
+            await _dbContext.SaveChangesAsync();
+        }
     }
 }

--- a/RentACar.Web/Controllers/SendEmailController.cs
+++ b/RentACar.Web/Controllers/SendEmailController.cs
@@ -53,7 +53,7 @@ namespace RentACar.Web.Controllers
         }
 
         [HttpPost("Send")]
-        public async Task<IActionResult> Send([FromBody] SendEmailRequestDto request)
+        public async Task<IActionResult> Send([FromForm] SendEmailRequestDto request)
         {
              if (request == null) return BadRequest("Invalid request");
 
@@ -174,12 +174,38 @@ namespace RentACar.Web.Controllers
              return Ok(draft);
         }
 
+        [HttpGet("Drafts")]
+        public async Task<IActionResult> Drafts()
+        {
+            var userId = _userManager.GetUserId(User);
+            var drafts = await _draftManager.GetDraftsByUserAsync(userId);
+            var response = drafts.Select(draft => new
+            {
+                id = draft.Id,
+                subject = draft.Subject,
+                body = draft.Body,
+                recipientsRaw = draft.RecipientsRaw,
+                selectedDistributionListIdsRaw = draft.SelectedDistributionListIdsRaw,
+                lastUpdated = draft.LastUpdated.ToString("MMM dd")
+            });
+
+            return Ok(response);
+        }
+
         [HttpDelete("DeleteDraft/{id}")]
         public async Task<IActionResult> DeleteDraft(int id)
         {
              var userId = _userManager.GetUserId(User);
              await _draftManager.DeleteDraftAsync(id, userId);
              return Ok(new { success = true });
+        }
+
+        [HttpDelete("DeleteAllDrafts")]
+        public async Task<IActionResult> DeleteAllDrafts()
+        {
+            var userId = _userManager.GetUserId(User);
+            await _draftManager.DeleteAllDraftsAsync(userId);
+            return Ok(new { success = true });
         }
     }
 }

--- a/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
+++ b/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
@@ -82,6 +82,86 @@
         /* Modal Styles */
         .modal { display: none; }
         .modal.open { display: flex; }
+        
+        /* Loading Overlay */
+        .loading-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.9);
+            backdrop-filter: blur(8px);
+            z-index: 9999;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .loading-overlay.active { display: flex; }
+        
+        .spinner {
+            width: 60px;
+            height: 60px;
+            border: 4px solid rgba(238, 192, 43, 0.1);
+            border-top-color: #eec02b;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        
+        @@keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        
+        /* Toast Notifications */
+        .toast-container {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 10000;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        
+        .toast {
+            min-width: 300px;
+            padding: 16px 20px;
+            background: #0a0a0a;
+            border: 1px solid #1a1a1a;
+            border-radius: 12px;
+            color: white;
+            font-size: 14px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+            animation: slideIn 0.3s ease-out;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+        
+        .toast.success { border-color: #22c55e; }
+        .toast.error { border-color: #ef4444; }
+        .toast.info { border-color: #eec02b; }
+        
+        .toast.removing {
+            animation: slideOut 0.3s ease-out;
+        }
+        
+        @@keyframes slideIn {
+            from {
+                transform: translateX(400px);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
+        
+        @@keyframes slideOut {
+            to {
+                transform: translateX(400px);
+                opacity: 0;
+            }
+        }
     </style>
 </head>
 
@@ -104,16 +184,22 @@
         <div id="drafts-list" class="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-2">
             @foreach (var draft in drafts)
             {
-                <div data-draft-item="true"
-                     onclick="loadDraft(@draft.Id,
-                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.Subject ?? "")),
-                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.Body ?? "")),
-                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.RecipientsRaw ?? "")),
-                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.SelectedDistributionListIdsRaw ?? "")))"
-                     class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
+                <div data-draft-item="true" data-draft-id="@draft.Id"
+                     onclick="loadDraft(@draft.Id)"
+                     class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group relative @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
                     <div class="flex justify-between items-start mb-1">
                         <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #@draft.Id</span>
-                        <span class="text-zinc-600 text-[9px]">@draft.LastUpdated.ToString("MMM dd")</span>
+                        <div class="flex items-center gap-2">
+                            <span class="text-zinc-600 text-[9px]">@draft.LastUpdated.ToString("MMM dd")</span>
+                            <button type="button" 
+                                    onclick="event.stopPropagation(); deleteDraft(@draft.Id)"
+                                    class="text-zinc-600 hover:text-primary transition-colors p-1"
+                                    title="Delete draft">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                </svg>
+                            </button>
+                        </div>
                     </div>
                     <p class="text-zinc-300 text-xs font-bold truncate mb-1">@(string.IsNullOrEmpty(draft.Subject) ? "No Subject" : draft.Subject)</p>
                     <p class="text-zinc-500 text-[10px] line-clamp-1 italic">@draft.RecipientsRaw</p>
@@ -121,9 +207,9 @@
             }
         </div>
 
-        <div class="p-6 border-t border-border-dark">
-            <button onclick="clearAllDrafts()"
-                    class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-3 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
+        <div class="p-3 border-t border-border-dark">
+            <button type="button" onclick="clearAllDrafts()"
+                    class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-2 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
                 <span class="material-symbols-outlined text-sm">delete</span>
                 Clear All Drafts
             </button>
@@ -296,10 +382,10 @@
         </div>
 
         <!-- Footer -->
-        <footer class="px-10 py-8 border-t border-border-dark bg-background-black flex items-center justify-between shrink-0 h-[90px]">
+        <footer class="px-10 py-3 border-t border-border-dark bg-background-black flex items-center justify-between shrink-0">
             <div class="flex items-center gap-6">
                 <button type="button" onclick="sendEmail()"
-                        class="bg-primary text-black px-12 py-4 rounded-xl text-xs font-black uppercase tracking-[0.2em] hover:bg-yellow-400 transition-all shadow-[0_8px_24px_0_rgba(238,192,43,0.25)] flex items-center gap-3">
+                        class="bg-primary text-black px-12 py-2 rounded-xl text-xs font-black uppercase tracking-[0.2em] hover:bg-yellow-400 transition-all shadow-[0_8px_24px_0_rgba(238,192,43,0.25)] flex items-center gap-3">
                     <span class="material-symbols-outlined font-black">send</span>
                     Send Message
                 </button>
@@ -316,6 +402,40 @@
             </button>
         </footer>
     </main>
+</div>
+
+<!-- Loading Overlay -->
+<div id="loadingOverlay" class="loading-overlay">
+    <div class="spinner"></div>
+    <p class="text-white text-lg font-bold" id="loadingText">Sending email...</p>
+</div>
+
+<!-- Toast Container -->
+<div id="toastContainer" class="toast-container"></div>
+
+</div>
+
+<!-- Confirmation Modal -->
+<div id="confirmationModal" class="modal fixed inset-0 z-50 bg-black/90 backdrop-blur-md items-center justify-center p-4">
+    <div class="bg-surface-dark border border-white/10 rounded-2xl w-full max-w-md overflow-hidden flex flex-col shadow-2xl">
+        <div class="p-6 text-center">
+            <div class="w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span class="material-symbols-outlined text-red-500 text-3xl">warning</span>
+            </div>
+            <h3 class="text-white text-xl font-bold mb-2" id="confirmTitle">Confirm Action</h3>
+            <p class="text-zinc-400 text-sm leading-relaxed" id="confirmMessage">Are you sure you want to proceed?</p>
+        </div>
+        <div class="p-4 bg-background-black border-t border-white/5 flex gap-3">
+            <button onclick="closeConfirmation()" 
+                    class="flex-1 px-4 py-3 rounded-xl text-xs font-bold uppercase tracking-widest text-zinc-400 hover:text-white hover:bg-white/5 transition-all">
+                Cancel
+            </button>
+            <button onclick="onConfirmAction()" 
+                    class="flex-1 px-4 py-3 rounded-xl text-xs font-bold uppercase tracking-widest bg-red-600 text-white hover:bg-red-500 transition-all shadow-lg shadow-red-900/20">
+                Confirm
+            </button>
+        </div>
+    </div>
 </div>
 
 <!-- Distribution List Modal -->
@@ -402,6 +522,39 @@
     console.log('Templates loaded:', sysTemplates);
     console.log('Distribution lists loaded:', distributionLists);
 
+    // Toast Notification System
+    function showToast(message, type = 'info') {
+        const container = document.getElementById('toastContainer');
+        const toast = document.createElement('div');
+        toast.className = `toast ${type}`;
+        
+        const icon = type === 'success' ? 'check_circle' : type === 'error' ? 'error' : 'info';
+        toast.innerHTML = `
+            <span class="material-symbols-outlined text-${type === 'success' ? 'green-500' : type === 'error' ? 'red-500' : 'primary'}">${icon}</span>
+            <span class="flex-1">${message}</span>
+        `;
+        
+        container.appendChild(toast);
+        
+        setTimeout(() => {
+            toast.classList.add('removing');
+            setTimeout(() => toast.remove(), 300);
+        }, 4000);
+    }
+
+    // Loading Overlay Controls
+    function showLoading(text = 'Processing...') {
+        const overlay = document.getElementById('loadingOverlay');
+        const loadingText = document.getElementById('loadingText');
+        loadingText.textContent = text;
+        overlay.classList.add('active');
+    }
+
+    function hideLoading() {
+        const overlay = document.getElementById('loadingOverlay');
+        overlay.classList.remove('active');
+    }
+
     function setMode(mode) {
         currentMode = mode;
         var btnManual = document.getElementById('btn-mode-manual');
@@ -417,6 +570,9 @@
             tmplSelector.classList.add('hidden');
             toolbar.classList.remove('hidden');
             sidebar.classList.add('hidden');
+            
+            // Clear editor when switching to manual mode
+            setEditorContent('');
         } else {
             btnTemplate.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all";
             btnManual.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all";
@@ -501,7 +657,7 @@
 
             if (!Array.isArray(sysTemplates)) {
                 console.error('sysTemplates invalid:', sysTemplates);
-                alert('Error: Templates data not loaded. Please refresh the page.');
+                showToast('Error: Templates data not loaded. Please refresh the page.', 'error');
                 return;
             }
 
@@ -511,14 +667,15 @@
                 document.getElementById('email-subject').value = tmpl.Subject || '';
                 setEditorContent(tmpl.Body || '');
                 focusEditor();
+                showToast('Template loaded successfully', 'success');
             } else {
                 console.error('Template not found for key:', key);
                 console.error('Available keys:', sysTemplates.map(t => t.TemplateKey));
-                alert('Template not found. Check console for details.');
+                showToast('Template not found. Check console for details.', 'error');
             }
         } catch (error) {
             console.error('Error in onTemplateSelect:', error);
-            alert('An error occurred while selecting the template: ' + error.message);
+            showToast('An error occurred while selecting the template', 'error');
         }
     }
 
@@ -547,7 +704,7 @@
         renderChips();
         updateHiddenInputs();
         closeDistListModal();
-        alert('Added ' + selectedIds.length + ' lists.');
+        showToast(`Added ${selectedIds.length} distribution list(s)`, 'success');
     }
 
     function removeDistList(id) {
@@ -595,16 +752,25 @@
         formData.append('TemplateKey', templateKey);
         attachmentFiles.forEach(file => formData.append('Attachments', file));
 
-        const response = await fetch('/Admin/EmailServices/SendEmail/Send', {
-            method: 'POST',
-            body: formData
-        });
+        showLoading('Sending email...');
+        
+        try {
+            const response = await fetch('/Admin/EmailServices/SendEmail/Send', {
+                method: 'POST',
+                body: formData
+            });
 
-        if (response.ok) {
-            var resData = await response.json();
-            alert('Email Sent successfully to ' + resData.deliveredCount + ' recipients!');
-        } else {
-            alert('Failed to send.');
+            if (response.ok) {
+                var resData = await response.json();
+                hideLoading();
+                showToast(`Email sent successfully to ${resData.deliveredCount} recipient(s)!`, 'success');
+            } else {
+                hideLoading();
+                showToast('Failed to send email', 'error');
+            }
+        } catch (error) {
+            hideLoading();
+            showToast('An error occurred while sending', 'error');
         }
     }
 
@@ -621,62 +787,151 @@
             SelectedDistributionListIdsRaw: document.getElementById('SelectedDistributionListIdsRaw').value
         };
 
-        const response = await fetch('/Admin/EmailServices/SendEmail/SaveDraft', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
-        });
-
-        if (response.ok) {
-            var res = await response.json();
-            currentDraftId = res.draftId;
-            alert('Draft Saved! ID: ' + res.draftId);
-            await refreshDrafts();
-        }
-    }
-
-    function loadDraft(id, subject, body, recipientsStr, selectedDistIdsRaw) {
-        currentDraftId = id;
-        document.getElementById('email-subject').value = subject || '';
-        setEditorContent(body || '');
-
-        recipients = [];
-        if (recipientsStr) {
-            recipientsStr.split(',').forEach(e => {
-                if (e && validateEmail(e.trim())) addRecipient(e.trim());
+        showLoading('Saving draft...');
+        
+        try {
+            const response = await fetch('/Admin/EmailServices/SendEmail/SaveDraft', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
             });
-        } else {
-            renderChips();
-        }
 
-        selectedDistLists = [];
-        if (selectedDistIdsRaw) {
-            var selectedIds = selectedDistIdsRaw.split(',').map(x => x.trim()).filter(Boolean);
-            selectedDistLists = distributionLists
-                .filter(list => selectedIds.includes(list.Id.toString()))
-                .map(list => ({ id: list.Id.toString(), name: list.Name }));
+            if (response.ok) {
+                var res = await response.json();
+                currentDraftId = res.draftId;
+                hideLoading();
+                showToast(`Draft saved! ID: ${res.draftId}`, 'success');
+                await refreshDrafts();
+            } else {
+                hideLoading();
+                showToast('Failed to save draft', 'error');
+            }
+        } catch (error) {
+            hideLoading();
+            showToast('An error occurred while saving', 'error');
         }
-
-        renderChips();
-        updateHiddenInputs();
-        syncDistListSelections();
     }
+
+    async function loadDraft(id) {
+        showLoading('Loading draft...');
+        try {
+            const response = await fetch(`/Admin/EmailServices/SendEmail/GetDraft/${id}`);
+            if (response.ok) {
+                const draft = await response.json();
+                currentDraftId = draft.id;
+                document.getElementById('email-subject').value = draft.subject || '';
+                setEditorContent(draft.body || '');
+
+                // Handle Recipients
+                recipients = [];
+                if (draft.recipientsRaw) {
+                    draft.recipientsRaw.split(',').forEach(e => {
+                        if (e && validateEmail(e.trim())) addRecipient(e.trim());
+                    });
+                } else {
+                    renderChips();
+                }
+
+                // Handle Dist Lists
+                selectedDistLists = [];
+                if (draft.selectedDistributionListIdsRaw) {
+                    var selectedIds = draft.selectedDistributionListIdsRaw.split(',').map(x => x.trim()).filter(Boolean);
+                    selectedDistLists = distributionLists
+                        .filter(list => selectedIds.includes(list.Id.toString()))
+                        .map(list => ({ id: list.Id.toString(), name: list.Name }));
+                }
+
+                renderChips();
+                updateHiddenInputs();
+                syncDistListSelections();
+                hideLoading();
+            } else {
+                hideLoading();
+                showToast('Failed to load draft', 'error');
+            }
+        } catch (error) {
+            hideLoading();
+            showToast('Error loading draft', 'error');
+            console.error(error);
+        }
+    }
+
+    // Confirmation Modal Logic
+    let confirmCallback = null;
+
+    function showConfirmation(title, message, callback) {
+        document.getElementById('confirmTitle').textContent = title;
+        document.getElementById('confirmMessage').textContent = message;
+        confirmCallback = callback;
+        document.getElementById('confirmationModal').classList.add('open');
+    }
+
+    function closeConfirmation() {
+        document.getElementById('confirmationModal').classList.remove('open');
+        confirmCallback = null;
+    }
+
+    function onConfirmAction() {
+        if (confirmCallback) confirmCallback();
+        closeConfirmation();
+    }
+
+    async function deleteDraft(draftId) {
+        showConfirmation('Delete Draft', 'Are you sure you want to delete this draft?', async () => {
+            showLoading('Deleting draft...');
+            try {
+                const response = await fetch(`/Admin/EmailServices/SendEmail/DeleteDraft/${draftId}`, { method: 'DELETE' });
+                
+                if (response.ok) {
+                    hideLoading();
+                    showToast('Draft deleted successfully', 'success');
+                    
+                    const draftItem = document.querySelector(`[data-draft-id="${draftId}"]`);
+                    if (draftItem) draftItem.remove();
+                    
+                    const countEl = document.getElementById('draft-count');
+                    const currentCount = parseInt(countEl.textContent) || 0;
+                    countEl.textContent = Math.max(0, currentCount - 1);
+                    
+                    if (currentDraftId === draftId) {
+                        currentDraftId = 0;
+                        document.getElementById('email-subject').value = '';
+                        setEditorContent('');
+                    }
+                } else {
+                    hideLoading();
+                    showToast('Failed to delete draft', 'error');
+                }
+            } catch (error) {
+                hideLoading();
+                showToast('An error occurred', 'error');
+            }
+        });
+    }
+
+
 
     function clearAllDrafts() {
-        if (!confirm('Delete all drafts? This cannot be undone.')) return;
-
-        fetch('/Admin/EmailServices/SendEmail/DeleteAllDrafts', { method: 'DELETE' })
-            .then(response => {
-                if (!response.ok) throw new Error('Failed to delete drafts.');
-                return response.json();
-            })
-            .then(() => {
-                document.querySelectorAll('[data-draft-item]').forEach(item => item.remove());
-                document.getElementById('draft-count').textContent = '0';
-                currentDraftId = 0;
-                alert('All drafts deleted.');
-            })
-            .catch(() => alert('Failed to delete drafts.'));
+        showConfirmation('Clear All Drafts', 'Are you sure you want to delete ALL drafts? This cannot be undone.', () => {
+            showLoading('Deleting all drafts...');
+            
+            fetch('/Admin/EmailServices/SendEmail/DeleteAllDrafts', { method: 'DELETE' })
+                .then(response => {
+                    if (!response.ok) throw new Error('Failed to delete drafts.');
+                    return response.json();
+                })
+                .then(() => {
+                    hideLoading();
+                    document.querySelectorAll('[data-draft-item]').forEach(item => item.remove());
+                    document.getElementById('draft-count').textContent = '0';
+                    currentDraftId = 0;
+                    showToast('All drafts deleted successfully', 'success');
+                })
+                .catch(() => {
+                    hideLoading();
+                    showToast('Failed to delete drafts', 'error');
+                });
+        });
     }
 
     async function refreshDrafts() {

--- a/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
+++ b/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
@@ -169,8 +169,8 @@
 <div class="flex h-screen w-full relative">
     <!-- Drafts Sidebar (25%) -->
     <aside class="w-[25%] bg-background-black border-r border-border-dark flex flex-col h-full overflow-hidden shrink-0">
-        <div class="p-8 border-b border-border-dark">
-            <div class="flex items-center justify-between mb-6">
+        <div class="p-4 border-b border-border-dark">
+            <div class="flex items-center justify-between mb-5">
                 <h3 class="text-white font-extrabold text-sm tracking-[0.2em] uppercase">Drafts</h3>
                 <span id="draft-count" class="bg-primary/20 text-primary text-[10px] font-black px-2 py-0.5 rounded-full">@drafts.Count</span>
             </div>

--- a/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
+++ b/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
@@ -62,17 +62,17 @@
         <div class="p-8 border-b border-border-dark">
             <div class="flex items-center justify-between mb-6">
                 <h3 class="text-white font-extrabold text-sm tracking-[0.2em] uppercase">Drafts</h3>
-                <span class="bg-primary/20 text-primary text-[10px] font-black px-2 py-0.5 rounded-full">@(((List<RentACar.Application.DTOs.EmailDraftDto>)ViewBag.Drafts).Count)</span>
+                <span id="draft-count" class="bg-primary/20 text-primary text-[10px] font-black px-2 py-0.5 rounded-full">@(((List<RentACar.Application.DTOs.EmailDraftDto>)ViewBag.Drafts).Count)</span>
             </div>
             <div class="relative">
                 <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">search</span>
                 <input class="w-full bg-surface-dark border border-border-dark rounded-lg pl-9 pr-4 py-2 text-xs text-white focus:ring-1 focus:ring-primary focus:border-primary outline-none" placeholder="Search drafts..." type="text" id="draftSearch"/>
             </div>
         </div>
-        <div class="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-2">
+        <div id="drafts-list" class="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-2">
             @foreach (var draft in (List<RentACar.Application.DTOs.EmailDraftDto>)ViewBag.Drafts)
             {
-                <div onclick="loadDraft(@draft.Id, '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Subject)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Body)', '@draft.RecipientsRaw')" class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
+                <div data-draft-item="true" onclick="loadDraft(@draft.Id, '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Subject)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Body)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.RecipientsRaw)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.SelectedDistributionListIdsRaw)')" class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
                     <div class="flex justify-between items-start mb-1">
                         <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #@draft.Id</span>
                         <span class="text-zinc-600 text-[9px]">@draft.LastUpdated.ToString("MMM dd")</span>
@@ -83,7 +83,7 @@
             }
         </div>
         <div class="p-6 border-t border-border-dark">
-            <button class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-3 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
+            <button onclick="clearAllDrafts()" class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-3 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
                 <span class="material-symbols-outlined text-sm">delete</span>
                 Clear All Drafts
             </button>
@@ -170,15 +170,30 @@
                         <button onclick="execCmd('insertOrderedList')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_list_numbered</span></button>
                         <div class="w-px h-6 bg-border-dark mx-2"></div>
                         <!-- Links/Images omitted for brevity of tool, but logic is same -->
-                        <button class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">link</span></button>
+                        <button onclick="insertLink()" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">link</span></button>
                         <div class="flex-1"></div>
                         <button onclick="execCmd('undo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">undo</span></button>
                         <button onclick="execCmd('redo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">redo</span></button>
                     </div>
                     
                     <!-- Content Area -->
-                    <div id="email-body-editor" class="p-10 text-lg leading-relaxed text-zinc-300 focus:outline-none flex-1 overflow-y-auto custom-scrollbar" contenteditable="true" spellcheck="false">
+                    <div id="email-body-editor" class="p-10 text-lg leading-relaxed text-zinc-300 focus:outline-none flex-1 overflow-y-auto custom-scrollbar" contenteditable="true" spellcheck="false" data-placeholder="Start typing your message here...">
                         <p class="text-zinc-600 italic">Start typing your message here...</p>
+                    </div>
+                </div>
+
+                <div class="mt-6">
+                    <label class="block text-zinc-500 text-[10px] font-black uppercase tracking-[0.2em] mb-3">Attachments</label>
+                    <div class="flex flex-col gap-3 bg-background-black border border-border-dark rounded-xl p-4">
+                        <div class="flex items-center gap-3">
+                            <input id="attachment-input" type="file" multiple class="hidden" />
+                            <button onclick="triggerAttachmentPicker()" class="text-primary text-[10px] font-black uppercase tracking-widest border border-primary/30 px-4 py-2 rounded-lg hover:bg-primary/10 transition-all flex items-center gap-2">
+                                <span class="material-symbols-outlined text-[16px]">attach_file</span>
+                                Add documents
+                            </button>
+                            <span class="text-zinc-500 text-xs" id="attachment-count">No files attached</span>
+                        </div>
+                        <div id="attachment-list" class="flex flex-wrap gap-2"></div>
                     </div>
                 </div>
             </div>
@@ -267,12 +282,16 @@
 <!-- Store Templates in JS for Fast Switching -->
 <script>
     var sysTemplates = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.Templates));
+    var distributionLists = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.DistributionLists));
 </script>
 
 <script>
     var currentMode = 'manual';
     var recipients = [];
     var selectedDistLists = [];
+    var currentDraftId = 0;
+    var attachmentFiles = [];
+    var savedSelectionRange = null;
 
     function setMode(mode) {
             currentMode = mode;
@@ -301,8 +320,9 @@
         
         // Toolbar Logic
         function execCmd(command, value = null) {
+            restoreSelection();
             document.execCommand(command, false, value);
-            document.getElementById('email-body-editor').focus();
+            focusEditor();
         }
 
         // Recipients Handling (Chips)
@@ -340,11 +360,17 @@
                 chip.innerHTML = `${email} <button onclick="removeRecipient('${email}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
                 container.appendChild(chip);
             });
-            // Show selected lists chip? maybe
+            selectedDistLists.forEach(list => {
+                var listChip = document.createElement('div');
+                listChip.className = "bg-zinc-800 text-primary text-[11px] font-extrabold px-3 py-1.5 rounded-full flex items-center gap-2 border border-primary/30";
+                listChip.innerHTML = `${list.name} <button onclick="removeDistList('${list.id}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
+                container.appendChild(listChip);
+            });
         }
 
         function updateHiddenInputs() {
             document.getElementById('RecipientsRaw').value = recipients.join(',');
+            document.getElementById('SelectedDistributionListIdsRaw').value = selectedDistLists.map(l => l.id).join(',');
         }
 
         function validateEmail(email) {
@@ -362,7 +388,8 @@
             if(tmpl) {
                 // Populate editor
                 document.getElementById('email-subject').value = tmpl.Subject;
-                document.getElementById('email-body-editor').innerHTML = tmpl.Body;
+                setEditorContent(tmpl.Body);
+                focusEditor();
             }
         }
         
@@ -372,6 +399,7 @@
 
         // Modals
         function openDistListModal() {
+            syncDistListSelections();
             document.getElementById('distListModal').classList.add('open');
         }
         function closeDistListModal() {
@@ -379,11 +407,15 @@
         }
         function confirmDistLists() {
             var checkboxes = document.querySelectorAll('input[name="distListIds"]:checked');
-            var ids = [];
-            checkboxes.forEach(cb => ids.push(cb.value));
-            document.getElementById('SelectedDistributionListIdsRaw').value = ids.join(',');
+            var selectedIds = [];
+            checkboxes.forEach(cb => selectedIds.push(cb.value));
+            selectedDistLists = distributionLists
+                .filter(list => selectedIds.includes(list.Id.toString()))
+                .map(list => ({ id: list.Id.toString(), name: list.Name }));
+            renderChips();
+            updateHiddenInputs();
             closeDistListModal();
-            alert('Added ' + ids.length + ' lists.');
+            alert('Added ' + selectedIds.length + ' lists.');
         }
 
         function openPreview() {
@@ -409,19 +441,18 @@
              // Ensure hidden inputs updated
              updateHiddenInputs();
 
-             var payload = {
-                 RecipientsRaw: document.getElementById('RecipientsRaw').value,
-                 SelectedDistributionListIdsRaw: document.getElementById('SelectedDistributionListIdsRaw').value,
-                 Subject: subject,
-                 Body: body,
-                 IsTemplateMode: currentMode === 'template',
-                 TemplateKey: templateKey
-             };
+             var formData = new FormData();
+             formData.append('RecipientsRaw', document.getElementById('RecipientsRaw').value);
+             formData.append('SelectedDistributionListIdsRaw', document.getElementById('SelectedDistributionListIdsRaw').value);
+             formData.append('Subject', subject);
+             formData.append('Body', body);
+             formData.append('IsTemplateMode', currentMode === 'template');
+             formData.append('TemplateKey', templateKey);
+             attachmentFiles.forEach(file => formData.append('Attachments', file));
 
              const response = await fetch('/Admin/EmailServices/SendEmail/Send', {
                  method: 'POST',
-                 headers: { 'Content-Type': 'application/json' },
-                 body: JSON.stringify(payload)
+                 body: formData
              });
              
              if(response.ok) {
@@ -438,7 +469,7 @@
              updateHiddenInputs();
 
              var payload = {
-                 Id: 0, // 0 for new, or need to track current draft ID
+                 Id: currentDraftId,
                  Subject: subject,
                  Body: body,
                  RecipientsRaw: document.getElementById('RecipientsRaw').value,
@@ -453,14 +484,16 @@
              
             if(response.ok) {
                  var res = await response.json();
+                 currentDraftId = res.draftId;
                  alert('Draft Saved! ID: ' + res.draftId);
-                 // reload page or sidebar?
+                 await refreshDrafts();
              }
         }
         
-        function loadDraft(id, subject, body, recipientsStr) {
+        function loadDraft(id, subject, body, recipientsStr, selectedDistIdsRaw) {
+            currentDraftId = id;
             document.getElementById('email-subject').value = subject;
-            document.getElementById('email-body-editor').innerHTML = body;
+            setEditorContent(body);
             
             // clear recipients
             recipients = [];
@@ -471,8 +504,177 @@
             } else {
                 renderChips();
             }
+
+            selectedDistLists = [];
+            if (selectedDistIdsRaw) {
+                var selectedIds = selectedDistIdsRaw.split(',').map(id => id.trim()).filter(Boolean);
+                selectedDistLists = distributionLists
+                    .filter(list => selectedIds.includes(list.Id.toString()))
+                    .map(list => ({ id: list.Id.toString(), name: list.Name }));
+            }
+            renderChips();
+            updateHiddenInputs();
+            syncDistListSelections();
         }
 
+        function removeDistList(id) {
+            selectedDistLists = selectedDistLists.filter(list => list.id !== id);
+            renderChips();
+            updateHiddenInputs();
+            syncDistListSelections();
+        }
+
+        function syncDistListSelections() {
+            var selectedIds = selectedDistLists.map(list => list.id);
+            document.querySelectorAll('input[name="distListIds"]').forEach(cb => {
+                cb.checked = selectedIds.includes(cb.value);
+            });
+        }
+
+        function triggerAttachmentPicker() {
+            document.getElementById('attachment-input').click();
+        }
+
+        function handleAttachmentChange(event) {
+            Array.from(event.target.files).forEach(file => {
+                if (!attachmentFiles.some(existing => existing.name === file.name && existing.size === file.size)) {
+                    attachmentFiles.push(file);
+                }
+            });
+            syncAttachmentInput();
+            renderAttachments();
+        }
+
+        function removeAttachment(index) {
+            attachmentFiles.splice(index, 1);
+            syncAttachmentInput();
+            renderAttachments();
+        }
+
+        function syncAttachmentInput() {
+            var dataTransfer = new DataTransfer();
+            attachmentFiles.forEach(file => dataTransfer.items.add(file));
+            document.getElementById('attachment-input').files = dataTransfer.files;
+        }
+
+        function renderAttachments() {
+            var list = document.getElementById('attachment-list');
+            var count = document.getElementById('attachment-count');
+            list.innerHTML = '';
+            if (attachmentFiles.length === 0) {
+                count.textContent = 'No files attached';
+                return;
+            }
+
+            count.textContent = `${attachmentFiles.length} file(s) attached`;
+            attachmentFiles.forEach((file, index) => {
+                var item = document.createElement('div');
+                item.className = "bg-zinc-800 text-zinc-200 text-[11px] font-semibold px-3 py-1.5 rounded-full flex items-center gap-2 border border-white/10";
+                item.innerHTML = `${file.name} <button onclick="removeAttachment(${index})" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
+                list.appendChild(item);
+            });
+        }
+
+        function clearAllDrafts() {
+            if (!confirm('Delete all drafts? This cannot be undone.')) return;
+            fetch('/Admin/EmailServices/SendEmail/DeleteAllDrafts', { method: 'DELETE' })
+                .then(response => {
+                    if (!response.ok) throw new Error('Failed to delete drafts.');
+                    return response.json();
+                })
+                .then(() => {
+                    document.querySelectorAll('[data-draft-item]').forEach(item => item.remove());
+                    document.getElementById('draft-count').textContent = '0';
+                    currentDraftId = 0;
+                    alert('All drafts deleted.');
+                })
+                .catch(() => alert('Failed to delete drafts.'));
+        }
+
+        async function refreshDrafts() {
+            const response = await fetch('/Admin/EmailServices/SendEmail/Drafts');
+            if (!response.ok) return;
+            const drafts = await response.json();
+            var draftList = document.getElementById('drafts-list');
+            if (!draftList) return;
+            draftList.innerHTML = '';
+            drafts.forEach(draft => {
+                var item = document.createElement('div');
+                item.setAttribute('data-draft-item', 'true');
+                item.className = "p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group";
+                item.onclick = () => loadDraft(draft.id, draft.subject, draft.body, draft.recipientsRaw, draft.selectedDistributionListIdsRaw);
+                item.innerHTML = `
+                    <div class="flex justify-between items-start mb-1">
+                        <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #${draft.id}</span>
+                        <span class="text-zinc-600 text-[9px]">${draft.lastUpdated}</span>
+                    </div>
+                    <p class="text-zinc-300 text-xs font-bold truncate mb-1">${draft.subject || 'No Subject'}</p>
+                    <p class="text-zinc-500 text-[10px] line-clamp-1 italic">${draft.recipientsRaw || ''}</p>
+                `;
+                draftList.appendChild(item);
+            });
+            document.getElementById('draft-count').textContent = drafts.length.toString();
+        }
+
+        function focusEditor() {
+            document.getElementById('email-body-editor').focus();
+        }
+
+        function saveSelection() {
+            var selection = window.getSelection();
+            if (selection.rangeCount === 0) return;
+            var range = selection.getRangeAt(0);
+            var editor = document.getElementById('email-body-editor');
+            if (editor.contains(range.commonAncestorContainer)) {
+                savedSelectionRange = range;
+            }
+        }
+
+        function restoreSelection() {
+            if (!savedSelectionRange) return;
+            var selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(savedSelectionRange);
+        }
+
+        function setEditorContent(html) {
+            var editor = document.getElementById('email-body-editor');
+            editor.innerHTML = html && html.trim() ? html : `<p class="text-zinc-600 italic">${editor.dataset.placeholder}</p>`;
+        }
+
+        function insertLink() {
+            var url = prompt('Enter URL');
+            if (!url) return;
+            if (!/^https?:\/\//i.test(url)) {
+                url = `https://${url}`;
+            }
+            restoreSelection();
+            var selection = window.getSelection();
+            if (selection && selection.isCollapsed) {
+                document.execCommand('insertHTML', false, `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
+            } else {
+                document.execCommand('createLink', false, url);
+            }
+            focusEditor();
+        }
+
+        document.getElementById('attachment-input').addEventListener('change', handleAttachmentChange);
+        document.addEventListener('selectionchange', saveSelection);
+        document.getElementById('email-body-editor').addEventListener('focus', saveSelection);
+        document.getElementById('email-body-editor').addEventListener('blur', saveSelection);
+
+        document.getElementById('email-body-editor').addEventListener('input', function() {
+            if (this.textContent.trim() === '') {
+                setEditorContent('');
+            }
+        });
+
+        document.getElementById('email-body-editor').addEventListener('focus', function() {
+            var placeholder = this.dataset.placeholder;
+            if (this.textContent.trim() === placeholder) {
+                this.innerHTML = '';
+            }
+        });
     </script>
 </body>
 </html>

--- a/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
+++ b/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
@@ -1,17 +1,46 @@
 @model RentACar.Application.DTOs.EmailDraftDto
+@using System.Text
+@using Newtonsoft.Json
+
 @{
-    Layout = null; // Removed Layout as requested
+    Layout = null;
+
+    // SAFE defaults to avoid null reference issues
+    var drafts = (List<RentACar.Application.DTOs.EmailDraftDto>)(ViewBag.Drafts ?? new List<RentACar.Application.DTOs.EmailDraftDto>());
+    var templates = (List<RentACar.Core.Entities.EmailTemplate>)(ViewBag.Templates ?? new List<RentACar.Core.Entities.EmailTemplate>());
+    var distLists = (List<RentACar.Application.DTOs.DistributionListDto>)(ViewBag.DistributionLists ?? new List<RentACar.Application.DTOs.DistributionListDto>());
+
+    // Serialize only what the client needs (avoid circular references)
+    var safeTemplates = templates.Select(t => new {
+        TemplateKey = t.TemplateKey,
+        Name = t.Name,
+        Subject = t.Subject,
+        Body = t.Body
+    }).ToList();
+
+    var jsonSettings = new JsonSerializerSettings {
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        StringEscapeHandling = StringEscapeHandling.EscapeHtml
+    };
+
+    var templatesJson = JsonConvert.SerializeObject(safeTemplates, jsonSettings);
+    var distListsJson = JsonConvert.SerializeObject(distLists, jsonSettings);
+
+    // Base64 encode to completely avoid escaping issues
+    var templatesB64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(templatesJson));
+    var distListsB64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(distListsJson));
 }
 
 <!DOCTYPE html>
 <html class="dark" lang="en">
-<head> 
+<head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Email Composer | RentACar</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+
     <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -34,6 +63,7 @@
             },
         }
     </script>
+
     <style>
         .custom-scrollbar::-webkit-scrollbar { width: 4px; }
         .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
@@ -49,12 +79,12 @@
             background: rgba(238, 192, 43, 0.15);
             box-shadow: 0 0 10px rgba(238, 192, 43, 0.2);
         }
-        
         /* Modal Styles */
         .modal { display: none; }
         .modal.open { display: flex; }
     </style>
 </head>
+
 <body class="bg-background-black font-display text-white min-h-screen overflow-hidden">
 <div class="flex h-screen w-full relative">
     <!-- Drafts Sidebar (25%) -->
@@ -62,17 +92,25 @@
         <div class="p-8 border-b border-border-dark">
             <div class="flex items-center justify-between mb-6">
                 <h3 class="text-white font-extrabold text-sm tracking-[0.2em] uppercase">Drafts</h3>
-                <span id="draft-count" class="bg-primary/20 text-primary text-[10px] font-black px-2 py-0.5 rounded-full">@(((List<RentACar.Application.DTOs.EmailDraftDto>)ViewBag.Drafts).Count)</span>
+                <span id="draft-count" class="bg-primary/20 text-primary text-[10px] font-black px-2 py-0.5 rounded-full">@drafts.Count</span>
             </div>
             <div class="relative">
                 <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">search</span>
-                <input class="w-full bg-surface-dark border border-border-dark rounded-lg pl-9 pr-4 py-2 text-xs text-white focus:ring-1 focus:ring-primary focus:border-primary outline-none" placeholder="Search drafts..." type="text" id="draftSearch"/>
+                <input class="w-full bg-surface-dark border border-border-dark rounded-lg pl-9 pr-4 py-2 text-xs text-white focus:ring-1 focus:ring-primary focus:border-primary outline-none"
+                       placeholder="Search drafts..." type="text" id="draftSearch"/>
             </div>
         </div>
+
         <div id="drafts-list" class="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-2">
-            @foreach (var draft in (List<RentACar.Application.DTOs.EmailDraftDto>)ViewBag.Drafts)
+            @foreach (var draft in drafts)
             {
-                <div data-draft-item="true" onclick="loadDraft(@draft.Id, '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Subject)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.Body)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.RecipientsRaw)', '@System.Web.HttpUtility.JavaScriptStringEncode(draft.SelectedDistributionListIdsRaw)')" class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
+                <div data-draft-item="true"
+                     onclick="loadDraft(@draft.Id,
+                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.Subject ?? "")),
+                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.Body ?? "")),
+                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.RecipientsRaw ?? "")),
+                         @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(draft.SelectedDistributionListIdsRaw ?? "")))"
+                     class="p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group @(Model != null && Model.Id == draft.Id ? "bg-primary/5 border-primary/20" : "")">
                     <div class="flex justify-between items-start mb-1">
                         <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #@draft.Id</span>
                         <span class="text-zinc-600 text-[9px]">@draft.LastUpdated.ToString("MMM dd")</span>
@@ -82,8 +120,10 @@
                 </div>
             }
         </div>
+
         <div class="p-6 border-t border-border-dark">
-            <button onclick="clearAllDrafts()" class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-3 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
+            <button onclick="clearAllDrafts()"
+                    class="w-full bg-surface-dark border border-border-dark text-zinc-400 py-3 rounded-lg text-[10px] font-extrabold uppercase tracking-widest hover:text-white hover:border-zinc-700 transition-all flex items-center justify-center gap-2">
                 <span class="material-symbols-outlined text-sm">delete</span>
                 Clear All Drafts
             </button>
@@ -94,17 +134,18 @@
     <main class="w-[75%] flex flex-col h-full bg-background-black relative">
         <header class="px-10 py-8 flex items-center justify-between border-b border-border-dark shrink-0">
             <div class="flex items-center gap-6">
-                <!-- Back button -->
                 <a href="/EmailServices/EmailServicesHub" class="text-zinc-500 hover:text-white transition-colors">
                     <span class="material-symbols-outlined">arrow_back</span>
                 </a>
                 <h2 class="text-white text-2xl font-black tracking-tight" id="pageTitle">New Message</h2>
             </div>
             <div class="flex items-center bg-surface-dark p-1 rounded-xl border border-border-dark">
-                <button onclick="setMode('manual')" id="btn-mode-manual" class="px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all">
+                <button onclick="setMode('manual')" id="btn-mode-manual"
+                        class="px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all">
                     Manual
                 </button>
-                <button onclick="setMode('template')" id="btn-mode-template" class="px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all">
+                <button onclick="setMode('template')" id="btn-mode-template"
+                        class="px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all">
                     Template
                 </button>
             </div>
@@ -113,7 +154,7 @@
         <div class="flex flex-1 overflow-hidden" id="main-scroll-area">
             <!-- EDITOR COLUMN -->
             <div class="flex-1 overflow-y-auto custom-scrollbar px-10 pb-8 pt-6 flex flex-col">
-                
+
                 <!-- Template Selector (Only in Template Mode) -->
                 <div id="template-selector-container" class="mb-8 hidden">
                     <label class="block text-zinc-500 text-[10px] font-black uppercase tracking-widest mb-3">Select System Template</label>
@@ -121,9 +162,11 @@
                         <div class="absolute inset-y-0 left-4 flex items-center pointer-events-none">
                             <span class="material-symbols-outlined text-primary text-xl">layers</span>
                         </div>
-                        <select onchange="onTemplateSelect(this)" class="w-full bg-surface-dark border border-border-dark rounded-lg pl-12 pr-10 py-4 text-white focus:ring-1 focus:ring-primary/40 focus:border-primary/40 appearance-none cursor-pointer text-sm">
+                        <select id="template-select"
+                                onchange="onTemplateSelect(this)"
+                                class="w-full bg-surface-dark border border-border-dark rounded-lg pl-12 pr-10 py-4 text-white focus:ring-1 focus:ring-primary/40 focus:border-primary/40 appearance-none cursor-pointer text-sm">
                             <option value="">-- Choose a Template --</option>
-                            @foreach (var tmpl in (List<RentACar.Core.Entities.EmailTemplate>)ViewBag.Templates)
+                            @foreach (var tmpl in templates)
                             {
                                 <option value="@tmpl.TemplateKey">@tmpl.Name</option>
                             }
@@ -138,56 +181,85 @@
                 <div class="mb-6">
                     <label class="block text-zinc-500 text-[10px] font-black uppercase tracking-[0.2em] mb-4">To: Recipients</label>
                     <div class="min-h-[60px] bg-background-black border border-border-dark rounded-xl p-3 flex flex-wrap gap-2 items-center focus-within:border-primary/50 transition-colors">
-                        <!-- Chips Container -->
                         <div id="recipients-chips" class="flex flex-wrap gap-2"></div>
-                        <input id="recipient-input" class="flex-1 bg-transparent border-none focus:ring-0 text-sm text-white min-w-[200px]" placeholder="Type email addresses..." type="text"/>
+                        <input id="recipient-input"
+                               class="flex-1 bg-transparent border-none focus:ring-0 text-sm text-white min-w-[200px]"
+                               placeholder="Type email addresses..." type="text"/>
                     </div>
-                    <!-- Distribution List Actions -->
+
                     <div class="flex gap-3 mt-4">
-                        <button onclick="openDistListModal()" class="text-primary text-[10px] font-black uppercase tracking-widest border border-primary/30 px-4 py-2 rounded-lg hover:bg-primary/10 transition-all flex items-center gap-2">
+                        <button type="button" onclick="openDistListModal()"
+                                class="text-primary text-[10px] font-black uppercase tracking-widest border border-primary/30 px-4 py-2 rounded-lg hover:bg-primary/10 transition-all flex items-center gap-2">
                             <span class="material-symbols-outlined text-[16px]">group</span>
                             Distribution Lists
                         </button>
                     </div>
-                    <input type="hidden" id="RecipientsRaw" name="RecipientsRaw" />
-                    <input type="hidden" id="SelectedDistributionListIdsRaw" name="SelectedDistributionListIdsRaw" />
+
+                    <input type="hidden" id="RecipientsRaw" name="RecipientsRaw"/>
+                    <input type="hidden" id="SelectedDistributionListIdsRaw" name="SelectedDistributionListIdsRaw"/>
                 </div>
 
                 <div class="mb-8">
                     <label class="block text-zinc-500 text-[10px] font-black uppercase tracking-[0.2em] mb-4">Subject</label>
-                    <input id="email-subject" class="w-full bg-background-black border border-primary rounded-xl px-4 py-4 text-white font-bold text-base focus:ring-2 focus:ring-primary/20 outline-none placeholder:text-zinc-700" placeholder="Enter message subject..." type="text"/>
+                    <input id="email-subject"
+                           class="w-full bg-background-black border border-primary rounded-xl px-4 py-4 text-white font-bold text-base focus:ring-2 focus:ring-primary/20 outline-none placeholder:text-zinc-700"
+                           placeholder="Enter message subject..." type="text"/>
                 </div>
 
-                <!-- Editor / Preview Area -->
+                <!-- Editor -->
                 <div class="flex-1 flex flex-col border border-border-dark rounded-2xl bg-surface-dark overflow-hidden min-h-[500px] editor-container transition-all relative">
-                    <!-- Toolbar -->
                     <div id="manual-toolbar" class="flex items-center gap-1 px-4 py-3 bg-zinc-900/50 border-b border-border-dark overflow-x-auto">
-                        <button onclick="execCmd('bold')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_bold</span></button>
-                        <button onclick="execCmd('italic')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_italic</span></button>
-                        <button onclick="execCmd('underline')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_underlined</span></button>
+                        <button type="button" onclick="execCmd('bold')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">format_bold</span>
+                        </button>
+                        <button type="button" onclick="execCmd('italic')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">format_italic</span>
+                        </button>
+                        <button type="button" onclick="execCmd('underline')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">format_underlined</span>
+                        </button>
+
                         <div class="w-px h-6 bg-border-dark mx-2"></div>
-                        <button onclick="execCmd('insertUnorderedList')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_list_bulleted</span></button>
-                        <button onclick="execCmd('insertOrderedList')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">format_list_numbered</span></button>
+
+                        <button type="button" onclick="execCmd('insertUnorderedList')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">format_list_bulleted</span>
+                        </button>
+                        <button type="button" onclick="execCmd('insertOrderedList')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">format_list_numbered</span>
+                        </button>
+
                         <div class="w-px h-6 bg-border-dark mx-2"></div>
-                        <!-- Links/Images omitted for brevity of tool, but logic is same -->
-                        <button onclick="insertLink()" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">link</span></button>
+
+                        <button type="button" onclick="insertLink()" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">link</span>
+                        </button>
+
                         <div class="flex-1"></div>
-                        <button onclick="execCmd('undo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">undo</span></button>
-                        <button onclick="execCmd('redo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5"><span class="material-symbols-outlined text-[20px]">redo</span></button>
+
+                        <button type="button" onclick="execCmd('undo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">undo</span>
+                        </button>
+                        <button type="button" onclick="execCmd('redo')" class="p-2 text-zinc-400 hover:text-white transition-colors rounded hover:bg-white/5">
+                            <span class="material-symbols-outlined text-[20px]">redo</span>
+                        </button>
                     </div>
-                    
-                    <!-- Content Area -->
-                    <div id="email-body-editor" class="p-10 text-lg leading-relaxed text-zinc-300 focus:outline-none flex-1 overflow-y-auto custom-scrollbar" contenteditable="true" spellcheck="false" data-placeholder="Start typing your message here...">
+
+                    <div id="email-body-editor"
+                         class="p-10 text-lg leading-relaxed text-zinc-300 focus:outline-none flex-1 overflow-y-auto custom-scrollbar"
+                         contenteditable="true" spellcheck="false"
+                         data-placeholder="Start typing your message here...">
                         <p class="text-zinc-600 italic">Start typing your message here...</p>
                     </div>
                 </div>
 
+                <!-- Attachments -->
                 <div class="mt-6">
                     <label class="block text-zinc-500 text-[10px] font-black uppercase tracking-[0.2em] mb-3">Attachments</label>
                     <div class="flex flex-col gap-3 bg-background-black border border-border-dark rounded-xl p-4">
                         <div class="flex items-center gap-3">
-                            <input id="attachment-input" type="file" multiple class="hidden" />
-                            <button onclick="triggerAttachmentPicker()" class="text-primary text-[10px] font-black uppercase tracking-widest border border-primary/30 px-4 py-2 rounded-lg hover:bg-primary/10 transition-all flex items-center gap-2">
+                            <input id="attachment-input" type="file" multiple class="hidden"/>
+                            <button type="button" onclick="triggerAttachmentPicker()"
+                                    class="text-primary text-[10px] font-black uppercase tracking-widest border border-primary/30 px-4 py-2 rounded-lg hover:bg-primary/10 transition-all flex items-center gap-2">
                                 <span class="material-symbols-outlined text-[16px]">attach_file</span>
                                 Add documents
                             </button>
@@ -199,7 +271,7 @@
             </div>
 
             <!-- Placeholders Sidebar (Template Mode Only) -->
-             <aside id="placeholders-sidebar" class="w-[300px] border-l border-border-dark flex flex-col bg-panel-dark hidden shrink-0">
+            <aside id="placeholders-sidebar" class="w-[300px] border-l border-border-dark flex flex-col bg-panel-dark hidden shrink-0">
                 <div class="p-6 border-b border-border-dark">
                     <h3 class="text-white font-black text-[11px] tracking-widest uppercase mb-1">Placeholders</h3>
                     <p class="text-zinc-500 text-[10px]">Inject dynamic logic into template</p>
@@ -208,9 +280,15 @@
                     <div>
                         <p class="text-zinc-600 text-[9px] font-black uppercase tracking-widest mb-3">Customer Core</p>
                         <div class="space-y-2">
-                             <button class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{CustomerName}}')"><span class="text-primary text-[11px] font-bold block">{{CustomerName}}</span></button>
-                             <button class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{BookingID}}')"><span class="text-primary text-[11px] font-bold block">{{BookingID}}</span></button>
-                             <button class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{Amount}}')"><span class="text-primary text-[11px] font-bold block">{{Amount}}</span></button>
+                            <button type="button" class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{CustomerName}}')">
+                                <span class="text-primary text-[11px] font-bold block">{{CustomerName}}</span>
+                            </button>
+                            <button type="button" class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{BookingID}}')">
+                                <span class="text-primary text-[11px] font-bold block">{{BookingID}}</span>
+                            </button>
+                            <button type="button" class="placeholder-token w-full text-left p-3 rounded-md group" onclick="insertPlaceholder('{{Amount}}')">
+                                <span class="text-primary text-[11px] font-bold block">{{Amount}}</span>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -220,15 +298,19 @@
         <!-- Footer -->
         <footer class="px-10 py-8 border-t border-border-dark bg-background-black flex items-center justify-between shrink-0 h-[90px]">
             <div class="flex items-center gap-6">
-                <button onclick="sendEmail()" class="bg-primary text-black px-12 py-4 rounded-xl text-xs font-black uppercase tracking-[0.2em] hover:bg-yellow-400 transition-all shadow-[0_8px_24px_0_rgba(238,192,43,0.25)] flex items-center gap-3">
+                <button type="button" onclick="sendEmail()"
+                        class="bg-primary text-black px-12 py-4 rounded-xl text-xs font-black uppercase tracking-[0.2em] hover:bg-yellow-400 transition-all shadow-[0_8px_24px_0_rgba(238,192,43,0.25)] flex items-center gap-3">
                     <span class="material-symbols-outlined font-black">send</span>
                     Send Message
                 </button>
-                <button onclick="saveDraft()" class="text-zinc-500 hover:text-white text-[10px] font-black uppercase tracking-widest transition-all px-4 py-2 border border-transparent hover:border-zinc-800 rounded-lg">
+
+                <button type="button" onclick="saveDraft()"
+                        class="text-zinc-500 hover:text-white text-[10px] font-black uppercase tracking-widest transition-all px-4 py-2 border border-transparent hover:border-zinc-800 rounded-lg">
                     Save as Draft
                 </button>
             </div>
-             <button onclick="openPreview()" class="group flex items-center gap-3 text-zinc-400 hover:text-primary transition-all">
+
+            <button type="button" onclick="openPreview()" class="group flex items-center gap-3 text-zinc-400 hover:text-primary transition-all">
                 <span class="text-[10px] font-black uppercase tracking-widest">Preview Message</span>
                 <span class="material-symbols-outlined text-[20px] group-hover:scale-110 transition-transform">visibility</span>
             </button>
@@ -240,14 +322,15 @@
 <div id="distListModal" class="modal fixed inset-0 z-50 bg-black/80 backdrop-blur-sm items-center justify-center p-4">
     <div class="bg-surface-dark border border-white/10 rounded-2xl w-full max-w-lg overflow-hidden flex flex-col max-h-[80vh]">
         <div class="p-6 border-b border-white/10 flex justify-between items-center">
-             <h3 class="text-white text-lg font-bold">Select Lists</h3>
-             <button onclick="closeDistListModal()" class="material-symbols-outlined text-zinc-500 hover:text-white">close</button>
+            <h3 class="text-white text-lg font-bold">Select Lists</h3>
+            <button type="button" onclick="closeDistListModal()" class="material-symbols-outlined text-zinc-500 hover:text-white">close</button>
         </div>
         <div class="p-6 overflow-y-auto custom-scrollbar space-y-3">
-            @foreach(var listDto in (List<RentACar.Application.DTOs.DistributionListDto>)ViewBag.DistributionLists)
+            @foreach (var listDto in distLists)
             {
                 <label class="flex items-center gap-4 p-4 rounded-xl bg-background-black border border-white/5 hover:border-primary/50 cursor-pointer group transition-all">
-                    <input type="checkbox" name="distListIds" value="@listDto.Id" class="form-checkbox text-primary rounded border-zinc-700 bg-zinc-900 focus:ring-primary h-5 w-5" />
+                    <input type="checkbox" name="distListIds" value="@listDto.Id"
+                           class="form-checkbox text-primary rounded border-zinc-700 bg-zinc-900 focus:ring-primary h-5 w-5"/>
                     <div>
                         <p class="text-white font-bold text-sm group-hover:text-primary transition-colors">@listDto.Name</p>
                         <p class="text-zinc-500 text-xs">@listDto.MemberCount members • @listDto.Description</p>
@@ -256,7 +339,9 @@
             }
         </div>
         <div class="p-6 border-t border-white/10 flex justify-end">
-            <button onclick="confirmDistLists()" class="bg-primary text-black px-6 py-2 rounded-lg text-xs font-bold uppercase hover:bg-yellow-400">Add Selected</button>
+            <button type="button" onclick="confirmDistLists()" class="bg-primary text-black px-6 py-2 rounded-lg text-xs font-bold uppercase hover:bg-yellow-400">
+                Add Selected
+            </button>
         </div>
     </div>
 </div>
@@ -265,467 +350,463 @@
 <div id="previewModal" class="modal fixed inset-0 z-50 bg-black/90 backdrop-blur-md items-center justify-center p-4">
     <div class="bg-white rounded-2xl w-full max-w-3xl overflow-hidden shadow-2xl flex flex-col max-h-[90vh]">
         <div class="p-4 bg-zinc-100 border-b border-zinc-200 flex justify-between items-center">
-             <div class="flex gap-2">
-                 <div class="w-3 h-3 rounded-full bg-red-500"></div>
-                 <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
-                 <div class="w-3 h-3 rounded-full bg-green-500"></div>
-             </div>
-             <p class="text-zinc-500 text-xs font-bold uppercase">Preview Mode</p>
-             <button onclick="closePreview()" class="material-symbols-outlined text-zinc-400 hover:text-zinc-800">close</button>
+            <div class="flex gap-2">
+                <div class="w-3 h-3 rounded-full bg-red-500"></div>
+                <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+                <div class="w-3 h-3 rounded-full bg-green-500"></div>
+            </div>
+            <p class="text-zinc-500 text-xs font-bold uppercase">Preview Mode</p>
+            <button type="button" onclick="closePreview()" class="material-symbols-outlined text-zinc-400 hover:text-zinc-800">close</button>
         </div>
-        <div id="preview-content" class="flex-1 bg-white p-8 overflow-y-auto text-black font-sans">
-             <!-- Content Here -->
-        </div>
+        <div id="preview-content" class="flex-1 bg-white p-8 overflow-y-auto text-black font-sans"></div>
     </div>
 </div>
 
-<!-- Store Templates in JS for Fast Switching -->
-<script id="templates-data" type="application/json">
-@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.Templates ?? new List<object>()))
-</script>
-<script id="distlists-data" type="application/json">
-@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.DistributionLists ?? new List<object>()))
-</script>
+<!-- Store data as Base64 to completely avoid escaping issues -->
+<script id="templates-data-b64" type="text/plain">@templatesB64</script>
+<script id="distlists-data-b64" type="text/plain">@distListsB64</script>
 
 <script>
-    // Global variables initialization
-    var sysTemplates = [];
-    var distributionLists = [];
-    
-    try {
-        var templatesDataEl = document.getElementById('templates-data');
-        if (templatesDataEl && templatesDataEl.textContent) {
-            sysTemplates = JSON.parse(templatesDataEl.textContent);
+    // Base64 JSON parser function
+    function parseBase64Json(elId) {
+        var el = document.getElementById(elId);
+        if (!el) {
+            console.error('Element not found:', elId);
+            return [];
         }
-    } catch (e) {
-        console.error('Failed to parse templates:', e);
-    }
-    
-    try {
-        var distListsDataEl = document.getElementById('distlists-data');
-        if (distListsDataEl && distListsDataEl.textContent) {
-            distributionLists = JSON.parse(distListsDataEl.textContent);
+        var b64 = (el.textContent || '').trim();
+        if (!b64) {
+            console.warn('No base64 data in:', elId);
+            return [];
         }
-    } catch (e) {
-        console.error('Failed to parse distribution lists:', e);
+        try {
+            var json = atob(b64);
+            return JSON.parse(json);
+        } catch (e) {
+            console.error('Failed to parse base64 json for:', elId, e);
+            return [];
+        }
     }
-    
+
+    // IMPORTANT: sysTemplates now comes ONLY from base64
+    var sysTemplates = parseBase64Json('templates-data-b64');
+    var distributionLists = parseBase64Json('distlists-data-b64');
+
     var currentMode = 'manual';
     var recipients = [];
     var selectedDistLists = [];
     var currentDraftId = 0;
     var attachmentFiles = [];
     var savedSelectionRange = null;
-    
-    // Log to verify templates are loaded
+
     console.log('Templates loaded:', sysTemplates);
     console.log('Distribution lists loaded:', distributionLists);
 
     function setMode(mode) {
-            currentMode = mode;
-            var btnManual = document.getElementById('btn-mode-manual');
-            var btnTemplate = document.getElementById('btn-mode-template');
-            var tmplSelector = document.getElementById('template-selector-container');
-            var toolbar = document.getElementById('manual-toolbar');
-            var sidebar = document.getElementById('placeholders-sidebar');
+        currentMode = mode;
+        var btnManual = document.getElementById('btn-mode-manual');
+        var btnTemplate = document.getElementById('btn-mode-template');
+        var tmplSelector = document.getElementById('template-selector-container');
+        var toolbar = document.getElementById('manual-toolbar');
+        var sidebar = document.getElementById('placeholders-sidebar');
 
-            if (mode === 'manual') {
-                btnManual.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all";
-                btnTemplate.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all";
-                
-                tmplSelector.classList.add('hidden');
-                toolbar.classList.remove('hidden');
-                sidebar.classList.add('hidden');
-            } else {
-                btnTemplate.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all";
-                btnManual.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all";
+        if (mode === 'manual') {
+            btnManual.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all";
+            btnTemplate.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all";
 
-                tmplSelector.classList.remove('hidden');
-                toolbar.classList.add('hidden');
-                sidebar.classList.remove('hidden'); // Show Sidebar in Template Mode
+            tmplSelector.classList.add('hidden');
+            toolbar.classList.remove('hidden');
+            sidebar.classList.add('hidden');
+        } else {
+            btnTemplate.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest bg-primary text-black transition-all";
+            btnManual.className = "px-6 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-zinc-500 hover:text-white transition-all";
+
+            tmplSelector.classList.remove('hidden');
+            toolbar.classList.add('hidden');
+            sidebar.classList.remove('hidden');
+        }
+    }
+
+    // Toolbar Logic
+    function execCmd(command, value = null) {
+        restoreSelection();
+        document.execCommand(command, false, value);
+        focusEditor();
+    }
+
+    // Recipients Handling (Chips)
+    var input = document.getElementById('recipient-input');
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            var val = this.value.trim();
+            if (val && validateEmail(val)) {
+                addRecipient(val);
+                this.value = '';
             }
         }
-        
-        // Toolbar Logic
-        function execCmd(command, value = null) {
-            restoreSelection();
-            document.execCommand(command, false, value);
-            focusEditor();
-        }
+    });
 
-        // Recipients Handling (Chips)
-        var input = document.getElementById('recipient-input');
-        input.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter' || e.key === ',') {
-                e.preventDefault();
-                var val = this.value.trim();
-                if (val && validateEmail(val)) {
-                    addRecipient(val);
-                    this.value = '';
-                }
-            }
+    function addRecipient(email) {
+        if (recipients.includes(email)) return;
+        recipients.push(email);
+        renderChips();
+        updateHiddenInputs();
+    }
+
+    function removeRecipient(email) {
+        recipients = recipients.filter(e => e !== email);
+        renderChips();
+        updateHiddenInputs();
+    }
+
+    function renderChips() {
+        var container = document.getElementById('recipients-chips');
+        container.innerHTML = '';
+
+        recipients.forEach(email => {
+            var chip = document.createElement('div');
+            chip.className = "bg-primary text-black text-[11px] font-extrabold px-3 py-1.5 rounded-full flex items-center gap-2 shadow-[0_2px_8px_rgba(238,192,43,0.3)]";
+            chip.innerHTML = `${email} <button type="button" onclick="removeRecipient('${email}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
+            container.appendChild(chip);
         });
 
-        function addRecipient(email) {
-            if(recipients.includes(email)) return;
-            recipients.push(email);
-            renderChips();
-            updateHiddenInputs();
-        }
+        selectedDistLists.forEach(list => {
+            var listChip = document.createElement('div');
+            listChip.className = "bg-zinc-800 text-primary text-[11px] font-extrabold px-3 py-1.5 rounded-full flex items-center gap-2 border border-primary/30";
+            listChip.innerHTML = `${list.name} <button type="button" onclick="removeDistList('${list.id}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
+            container.appendChild(listChip);
+        });
+    }
 
-        function removeRecipient(email) {
-            recipients = recipients.filter(e => e !== email);
-            renderChips();
-            updateHiddenInputs();
-        }
+    function updateHiddenInputs() {
+        document.getElementById('RecipientsRaw').value = recipients.join(',');
+        document.getElementById('SelectedDistributionListIdsRaw').value = selectedDistLists.map(l => l.id).join(',');
+    }
 
-        function renderChips() {
-            var container = document.getElementById('recipients-chips');
-            container.innerHTML = '';
-            recipients.forEach(email => {
-                var chip = document.createElement('div');
-                chip.className = "bg-primary text-black text-[11px] font-extrabold px-3 py-1.5 rounded-full flex items-center gap-2 shadow-[0_2px_8px_rgba(238,192,43,0.3)]";
-                chip.innerHTML = `${email} <button onclick="removeRecipient('${email}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
-                container.appendChild(chip);
-            });
-            selectedDistLists.forEach(list => {
-                var listChip = document.createElement('div');
-                listChip.className = "bg-zinc-800 text-primary text-[11px] font-extrabold px-3 py-1.5 rounded-full flex items-center gap-2 border border-primary/30";
-                listChip.innerHTML = `${list.name} <button onclick="removeDistList('${list.id}')" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
-                container.appendChild(listChip);
-            });
-        }
+    function validateEmail(email) {
+        return String(email)
+            .toLowerCase()
+            .match(/^(([^<>()[\]\\.,;:\s@@""]+(\.[^<>()[\]\\.,;:\s@@""]+)*)|("".+""))@@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
+    }
 
-        function updateHiddenInputs() {
-            document.getElementById('RecipientsRaw').value = recipients.join(',');
-            document.getElementById('SelectedDistributionListIdsRaw').value = selectedDistLists.map(l => l.id).join(',');
-        }
+    // Template Selection
+    function onTemplateSelect(elem) {
+        try {
+            var key = elem.value;
+            console.log('=== Template Selection Debug ===');
+            console.log('Selected key:', key);
 
-        function validateEmail(email) {
-            return String(email)
-                .toLowerCase()
-                .match(/^(([^<>()[\]\\.,;:\s@@""]+(\.[^<>()[\]\\.,;:\s@@""]+)*)|("".+""))@@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
-        }
+            if (!key) return;
 
-        // Template Selection
-        function onTemplateSelect(elem) {
-            try {
-                var key = elem.value;
-                console.log('Template selected:', key);
-                
-                if(!key) {
-                    console.log('No template key selected');
-                    return;
-                }
-                
-                // Check if sysTemplates is defined and is an array
-                if (typeof sysTemplates === 'undefined' || !Array.isArray(sysTemplates)) {
-                    console.error('sysTemplates is not defined or not an array:', sysTemplates);
-                    alert('Error: Templates data not loaded. Please refresh the page.');
-                    return;
-                }
-                
-                console.log('Available templates:', sysTemplates);
-                var tmpl = sysTemplates.find(t => t.TemplateKey === key);
-                
-                if(tmpl) {
-                    console.log('Found template:', tmpl);
-                    // Populate editor
-                    document.getElementById('email-subject').value = tmpl.Subject || '';
-                    setEditorContent(tmpl.Body || '');
-                    focusEditor();
-                } else {
-                    console.warn('Template not found for key:', key);
-                    alert('Template not found');
-                }
-            } catch (error) {
-                console.error('Error in onTemplateSelect:', error);
-                alert('An error occurred while selecting the template: ' + error.message);
-            }
-        }
-        
-        function insertPlaceholder(token) {
-            execCmd('insertText', token);
-        }
-
-        // Modals
-        function openDistListModal() {
-            syncDistListSelections();
-            document.getElementById('distListModal').classList.add('open');
-        }
-        function closeDistListModal() {
-            document.getElementById('distListModal').classList.remove('open');
-        }
-        function confirmDistLists() {
-            var checkboxes = document.querySelectorAll('input[name="distListIds"]:checked');
-            var selectedIds = [];
-            checkboxes.forEach(cb => selectedIds.push(cb.value));
-            selectedDistLists = distributionLists
-                .filter(list => selectedIds.includes(list.Id.toString()))
-                .map(list => ({ id: list.Id.toString(), name: list.Name }));
-            renderChips();
-            updateHiddenInputs();
-            closeDistListModal();
-            alert('Added ' + selectedIds.length + ' lists.');
-        }
-
-        function openPreview() {
-            var content = document.getElementById('email-body-editor').innerHTML;
-            document.getElementById('preview-content').innerHTML = content;
-            document.getElementById('previewModal').classList.add('open');
-        }
-        function closePreview() {
-            document.getElementById('previewModal').classList.remove('open');
-        }
-
-        // Sending Layer
-        async function sendEmail() {
-             var subject = document.getElementById('email-subject').value;
-             var body = document.getElementById('email-body-editor').innerHTML;
-             var templateKey = "";
-             
-             if (currentMode === 'template') {
-                 var sel = document.querySelector('#template-selector-container select');
-                 templateKey = sel.value;
-             }
-             
-             // Ensure hidden inputs updated
-             updateHiddenInputs();
-
-             var formData = new FormData();
-             formData.append('RecipientsRaw', document.getElementById('RecipientsRaw').value);
-             formData.append('SelectedDistributionListIdsRaw', document.getElementById('SelectedDistributionListIdsRaw').value);
-             formData.append('Subject', subject);
-             formData.append('Body', body);
-             formData.append('IsTemplateMode', currentMode === 'template');
-             formData.append('TemplateKey', templateKey);
-             attachmentFiles.forEach(file => formData.append('Attachments', file));
-
-             const response = await fetch('/Admin/EmailServices/SendEmail/Send', {
-                 method: 'POST',
-                 body: formData
-             });
-             
-             if(response.ok) {
-                 var resData = await response.json();
-                 alert('Email Sent successfully to ' + resData.deliveredCount + ' recipients!');
-             } else {
-                 alert('Failed to send.');
-             }
-        }
-        
-        async function saveDraft() {
-             var subject = document.getElementById('email-subject').value;
-             var body = document.getElementById('email-body-editor').innerHTML;
-             updateHiddenInputs();
-
-             var payload = {
-                 Id: currentDraftId,
-                 Subject: subject,
-                 Body: body,
-                 RecipientsRaw: document.getElementById('RecipientsRaw').value,
-                 SelectedDistributionListIdsRaw: document.getElementById('SelectedDistributionListIdsRaw').value
-             };
-             
-              const response = await fetch('/Admin/EmailServices/SendEmail/SaveDraft', {
-                 method: 'POST',
-                 headers: { 'Content-Type': 'application/json' },
-                 body: JSON.stringify(payload)
-             });
-             
-            if(response.ok) {
-                 var res = await response.json();
-                 currentDraftId = res.draftId;
-                 alert('Draft Saved! ID: ' + res.draftId);
-                 await refreshDrafts();
-             }
-        }
-        
-        function loadDraft(id, subject, body, recipientsStr, selectedDistIdsRaw) {
-            currentDraftId = id;
-            document.getElementById('email-subject').value = subject;
-            setEditorContent(body);
-            
-            // clear recipients
-            recipients = [];
-            if(recipientsStr) {
-                recipientsStr.split(',').forEach(e => {
-                    if(e) addRecipient(e.trim());
-                });
-            } else {
-                renderChips();
-            }
-
-            selectedDistLists = [];
-            if (selectedDistIdsRaw) {
-                var selectedIds = selectedDistIdsRaw.split(',').map(id => id.trim()).filter(Boolean);
-                selectedDistLists = distributionLists
-                    .filter(list => selectedIds.includes(list.Id.toString()))
-                    .map(list => ({ id: list.Id.toString(), name: list.Name }));
-            }
-            renderChips();
-            updateHiddenInputs();
-            syncDistListSelections();
-        }
-
-        function removeDistList(id) {
-            selectedDistLists = selectedDistLists.filter(list => list.id !== id);
-            renderChips();
-            updateHiddenInputs();
-            syncDistListSelections();
-        }
-
-        function syncDistListSelections() {
-            var selectedIds = selectedDistLists.map(list => list.id);
-            document.querySelectorAll('input[name="distListIds"]').forEach(cb => {
-                cb.checked = selectedIds.includes(cb.value);
-            });
-        }
-
-        function triggerAttachmentPicker() {
-            document.getElementById('attachment-input').click();
-        }
-
-        function handleAttachmentChange(event) {
-            Array.from(event.target.files).forEach(file => {
-                if (!attachmentFiles.some(existing => existing.name === file.name && existing.size === file.size)) {
-                    attachmentFiles.push(file);
-                }
-            });
-            syncAttachmentInput();
-            renderAttachments();
-        }
-
-        function removeAttachment(index) {
-            attachmentFiles.splice(index, 1);
-            syncAttachmentInput();
-            renderAttachments();
-        }
-
-        function syncAttachmentInput() {
-            var dataTransfer = new DataTransfer();
-            attachmentFiles.forEach(file => dataTransfer.items.add(file));
-            document.getElementById('attachment-input').files = dataTransfer.files;
-        }
-
-        function renderAttachments() {
-            var list = document.getElementById('attachment-list');
-            var count = document.getElementById('attachment-count');
-            list.innerHTML = '';
-            if (attachmentFiles.length === 0) {
-                count.textContent = 'No files attached';
+            if (!Array.isArray(sysTemplates)) {
+                console.error('sysTemplates invalid:', sysTemplates);
+                alert('Error: Templates data not loaded. Please refresh the page.');
                 return;
             }
 
-            count.textContent = `${attachmentFiles.length} file(s) attached`;
-            attachmentFiles.forEach((file, index) => {
-                var item = document.createElement('div');
-                item.className = "bg-zinc-800 text-zinc-200 text-[11px] font-semibold px-3 py-1.5 rounded-full flex items-center gap-2 border border-white/10";
-                item.innerHTML = `${file.name} <button onclick="removeAttachment(${index})" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
-                list.appendChild(item);
-            });
-        }
+            var tmpl = sysTemplates.find(t => t.TemplateKey === key);
 
-        function clearAllDrafts() {
-            if (!confirm('Delete all drafts? This cannot be undone.')) return;
-            fetch('/Admin/EmailServices/SendEmail/DeleteAllDrafts', { method: 'DELETE' })
-                .then(response => {
-                    if (!response.ok) throw new Error('Failed to delete drafts.');
-                    return response.json();
-                })
-                .then(() => {
-                    document.querySelectorAll('[data-draft-item]').forEach(item => item.remove());
-                    document.getElementById('draft-count').textContent = '0';
-                    currentDraftId = 0;
-                    alert('All drafts deleted.');
-                })
-                .catch(() => alert('Failed to delete drafts.'));
-        }
-
-        async function refreshDrafts() {
-            const response = await fetch('/Admin/EmailServices/SendEmail/Drafts');
-            if (!response.ok) return;
-            const drafts = await response.json();
-            var draftList = document.getElementById('drafts-list');
-            if (!draftList) return;
-            draftList.innerHTML = '';
-            drafts.forEach(draft => {
-                var item = document.createElement('div');
-                item.setAttribute('data-draft-item', 'true');
-                item.className = "p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group";
-                item.onclick = () => loadDraft(draft.id, draft.subject, draft.body, draft.recipientsRaw, draft.selectedDistributionListIdsRaw);
-                item.innerHTML = `
-                    <div class="flex justify-between items-start mb-1">
-                        <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #${draft.id}</span>
-                        <span class="text-zinc-600 text-[9px]">${draft.lastUpdated}</span>
-                    </div>
-                    <p class="text-zinc-300 text-xs font-bold truncate mb-1">${draft.subject || 'No Subject'}</p>
-                    <p class="text-zinc-500 text-[10px] line-clamp-1 italic">${draft.recipientsRaw || ''}</p>
-                `;
-                draftList.appendChild(item);
-            });
-            document.getElementById('draft-count').textContent = drafts.length.toString();
-        }
-
-        function focusEditor() {
-            document.getElementById('email-body-editor').focus();
-        }
-
-        function saveSelection() {
-            var selection = window.getSelection();
-            if (selection.rangeCount === 0) return;
-            var range = selection.getRangeAt(0);
-            var editor = document.getElementById('email-body-editor');
-            if (editor.contains(range.commonAncestorContainer)) {
-                savedSelectionRange = range;
-            }
-        }
-
-        function restoreSelection() {
-            if (!savedSelectionRange) return;
-            var selection = window.getSelection();
-            selection.removeAllRanges();
-            selection.addRange(savedSelectionRange);
-        }
-
-        function setEditorContent(html) {
-            var editor = document.getElementById('email-body-editor');
-            editor.innerHTML = html && html.trim() ? html : `<p class="text-zinc-600 italic">${editor.dataset.placeholder}</p>`;
-        }
-
-        function insertLink() {
-            var url = prompt('Enter URL');
-            if (!url) return;
-            if (!/^https?:\/\//i.test(url)) {
-                url = `https://${url}`;
-            }
-            restoreSelection();
-            var selection = window.getSelection();
-            if (selection && selection.isCollapsed) {
-                document.execCommand('insertHTML', false, `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
+            if (tmpl) {
+                document.getElementById('email-subject').value = tmpl.Subject || '';
+                setEditorContent(tmpl.Body || '');
+                focusEditor();
             } else {
-                document.execCommand('createLink', false, url);
+                console.error('Template not found for key:', key);
+                console.error('Available keys:', sysTemplates.map(t => t.TemplateKey));
+                alert('Template not found. Check console for details.');
             }
-            focusEditor();
+        } catch (error) {
+            console.error('Error in onTemplateSelect:', error);
+            alert('An error occurred while selecting the template: ' + error.message);
+        }
+    }
+
+    function insertPlaceholder(token) {
+        execCmd('insertText', token);
+    }
+
+    // Modals
+    function openDistListModal() {
+        syncDistListSelections();
+        document.getElementById('distListModal').classList.add('open');
+    }
+    function closeDistListModal() {
+        document.getElementById('distListModal').classList.remove('open');
+    }
+
+    function confirmDistLists() {
+        var checkboxes = document.querySelectorAll('input[name="distListIds"]:checked');
+        var selectedIds = [];
+        checkboxes.forEach(cb => selectedIds.push(cb.value));
+
+        selectedDistLists = distributionLists
+            .filter(list => selectedIds.includes(list.Id.toString()))
+            .map(list => ({ id: list.Id.toString(), name: list.Name }));
+
+        renderChips();
+        updateHiddenInputs();
+        closeDistListModal();
+        alert('Added ' + selectedIds.length + ' lists.');
+    }
+
+    function removeDistList(id) {
+        selectedDistLists = selectedDistLists.filter(list => list.id !== id);
+        renderChips();
+        updateHiddenInputs();
+        syncDistListSelections();
+    }
+
+    function syncDistListSelections() {
+        var selectedIds = selectedDistLists.map(list => list.id);
+        document.querySelectorAll('input[name="distListIds"]').forEach(cb => {
+            cb.checked = selectedIds.includes(cb.value);
+        });
+    }
+
+    function openPreview() {
+        var content = document.getElementById('email-body-editor').innerHTML;
+        document.getElementById('preview-content').innerHTML = content;
+        document.getElementById('previewModal').classList.add('open');
+    }
+    function closePreview() {
+        document.getElementById('previewModal').classList.remove('open');
+    }
+
+    // Sending Layer
+    async function sendEmail() {
+        var subject = document.getElementById('email-subject').value;
+        var body = document.getElementById('email-body-editor').innerHTML;
+        var templateKey = "";
+
+        if (currentMode === 'template') {
+            var sel = document.getElementById('template-select');
+            templateKey = sel ? sel.value : "";
         }
 
-        document.getElementById('attachment-input').addEventListener('change', handleAttachmentChange);
-        document.addEventListener('selectionchange', saveSelection);
-        document.getElementById('email-body-editor').addEventListener('focus', saveSelection);
-        document.getElementById('email-body-editor').addEventListener('blur', saveSelection);
+        updateHiddenInputs();
 
-        document.getElementById('email-body-editor').addEventListener('input', function() {
-            if (this.textContent.trim() === '') {
-                setEditorContent('');
-            }
+        var formData = new FormData();
+        formData.append('RecipientsRaw', document.getElementById('RecipientsRaw').value);
+        formData.append('SelectedDistributionListIdsRaw', document.getElementById('SelectedDistributionListIdsRaw').value);
+        formData.append('Subject', subject);
+        formData.append('Body', body);
+        formData.append('IsTemplateMode', currentMode === 'template');
+        formData.append('TemplateKey', templateKey);
+        attachmentFiles.forEach(file => formData.append('Attachments', file));
+
+        const response = await fetch('/Admin/EmailServices/SendEmail/Send', {
+            method: 'POST',
+            body: formData
         });
 
-        document.getElementById('email-body-editor').addEventListener('focus', function() {
-            var placeholder = this.dataset.placeholder;
-            if (this.textContent.trim() === placeholder) {
-                this.innerHTML = '';
+        if (response.ok) {
+            var resData = await response.json();
+            alert('Email Sent successfully to ' + resData.deliveredCount + ' recipients!');
+        } else {
+            alert('Failed to send.');
+        }
+    }
+
+    async function saveDraft() {
+        var subject = document.getElementById('email-subject').value;
+        var body = document.getElementById('email-body-editor').innerHTML;
+        updateHiddenInputs();
+
+        var payload = {
+            Id: currentDraftId,
+            Subject: subject,
+            Body: body,
+            RecipientsRaw: document.getElementById('RecipientsRaw').value,
+            SelectedDistributionListIdsRaw: document.getElementById('SelectedDistributionListIdsRaw').value
+        };
+
+        const response = await fetch('/Admin/EmailServices/SendEmail/SaveDraft', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        if (response.ok) {
+            var res = await response.json();
+            currentDraftId = res.draftId;
+            alert('Draft Saved! ID: ' + res.draftId);
+            await refreshDrafts();
+        }
+    }
+
+    function loadDraft(id, subject, body, recipientsStr, selectedDistIdsRaw) {
+        currentDraftId = id;
+        document.getElementById('email-subject').value = subject || '';
+        setEditorContent(body || '');
+
+        recipients = [];
+        if (recipientsStr) {
+            recipientsStr.split(',').forEach(e => {
+                if (e && validateEmail(e.trim())) addRecipient(e.trim());
+            });
+        } else {
+            renderChips();
+        }
+
+        selectedDistLists = [];
+        if (selectedDistIdsRaw) {
+            var selectedIds = selectedDistIdsRaw.split(',').map(x => x.trim()).filter(Boolean);
+            selectedDistLists = distributionLists
+                .filter(list => selectedIds.includes(list.Id.toString()))
+                .map(list => ({ id: list.Id.toString(), name: list.Name }));
+        }
+
+        renderChips();
+        updateHiddenInputs();
+        syncDistListSelections();
+    }
+
+    function clearAllDrafts() {
+        if (!confirm('Delete all drafts? This cannot be undone.')) return;
+
+        fetch('/Admin/EmailServices/SendEmail/DeleteAllDrafts', { method: 'DELETE' })
+            .then(response => {
+                if (!response.ok) throw new Error('Failed to delete drafts.');
+                return response.json();
+            })
+            .then(() => {
+                document.querySelectorAll('[data-draft-item]').forEach(item => item.remove());
+                document.getElementById('draft-count').textContent = '0';
+                currentDraftId = 0;
+                alert('All drafts deleted.');
+            })
+            .catch(() => alert('Failed to delete drafts.'));
+    }
+
+    async function refreshDrafts() {
+        const response = await fetch('/Admin/EmailServices/SendEmail/Drafts');
+        if (!response.ok) return;
+
+        const drafts = await response.json();
+        var draftList = document.getElementById('drafts-list');
+        if (!draftList) return;
+
+        draftList.innerHTML = '';
+        drafts.forEach(draft => {
+            var item = document.createElement('div');
+            item.setAttribute('data-draft-item', 'true');
+            item.className = "p-4 rounded-xl hover:bg-surface-dark border border-transparent hover:border-border-dark transition-all cursor-pointer group";
+            item.onclick = () => loadDraft(draft.id, draft.subject, draft.body, draft.recipientsRaw, draft.selectedDistributionListIdsRaw);
+
+            item.innerHTML = `
+                <div class="flex justify-between items-start mb-1">
+                    <span class="text-zinc-500 text-[10px] font-extrabold uppercase tracking-widest group-hover:text-primary transition-colors">Draft #${draft.id}</span>
+                    <span class="text-zinc-600 text-[9px]">${draft.lastUpdated}</span>
+                </div>
+                <p class="text-zinc-300 text-xs font-bold truncate mb-1">${draft.subject || 'No Subject'}</p>
+                <p class="text-zinc-500 text-[10px] line-clamp-1 italic">${draft.recipientsRaw || ''}</p>
+            `;
+            draftList.appendChild(item);
+        });
+
+        document.getElementById('draft-count').textContent = drafts.length.toString();
+    }
+
+    function focusEditor() {
+        document.getElementById('email-body-editor').focus();
+    }
+
+    function saveSelection() {
+        var selection = window.getSelection();
+        if (selection.rangeCount === 0) return;
+
+        var range = selection.getRangeAt(0);
+        var editor = document.getElementById('email-body-editor');
+        if (editor.contains(range.commonAncestorContainer)) savedSelectionRange = range;
+    }
+
+    function restoreSelection() {
+        if (!savedSelectionRange) return;
+        var selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(savedSelectionRange);
+    }
+
+    function setEditorContent(html) {
+        var editor = document.getElementById('email-body-editor');
+        editor.innerHTML = html && html.trim() ? html : `<p class="text-zinc-600 italic">${editor.dataset.placeholder}</p>`;
+    }
+
+    function insertLink() {
+        var url = prompt('Enter URL');
+        if (!url) return;
+
+        if (!/^https?:\/\//i.test(url)) url = `https://${url}`;
+
+        restoreSelection();
+        var selection = window.getSelection();
+        if (selection && selection.isCollapsed) {
+            document.execCommand('insertHTML', false, `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
+        } else {
+            document.execCommand('createLink', false, url);
+        }
+        focusEditor();
+    }
+
+    function triggerAttachmentPicker() {
+        document.getElementById('attachment-input').click();
+    }
+
+    function handleAttachmentChange(event) {
+        Array.from(event.target.files).forEach(file => {
+            if (!attachmentFiles.some(existing => existing.name === file.name && existing.size === file.size)) {
+                attachmentFiles.push(file);
             }
         });
-    </script>
+        syncAttachmentInput();
+        renderAttachments();
+    }
+
+    function removeAttachment(index) {
+        attachmentFiles.splice(index, 1);
+        syncAttachmentInput();
+        renderAttachments();
+    }
+
+    function syncAttachmentInput() {
+        var dataTransfer = new DataTransfer();
+        attachmentFiles.forEach(file => dataTransfer.items.add(file));
+        document.getElementById('attachment-input').files = dataTransfer.files;
+    }
+
+    function renderAttachments() {
+        var list = document.getElementById('attachment-list');
+        var count = document.getElementById('attachment-count');
+
+        list.innerHTML = '';
+        if (attachmentFiles.length === 0) {
+            count.textContent = 'No files attached';
+            return;
+        }
+
+        count.textContent = `${attachmentFiles.length} file(s) attached`;
+        attachmentFiles.forEach((file, index) => {
+            var item = document.createElement('div');
+            item.className = "bg-zinc-800 text-zinc-200 text-[11px] font-semibold px-3 py-1.5 rounded-full flex items-center gap-2 border border-white/10";
+            item.innerHTML = `${file.name} <button type="button" onclick="removeAttachment(${index})" class="material-symbols-outlined text-[14px] leading-none hover:opacity-70 cursor-pointer">close</button>`;
+            list.appendChild(item);
+        });
+    }
+
+    document.getElementById('attachment-input').addEventListener('change', handleAttachmentChange);
+    document.addEventListener('selectionchange', saveSelection);
+    document.getElementById('email-body-editor').addEventListener('focus', saveSelection);
+    document.getElementById('email-body-editor').addEventListener('blur', saveSelection);
+
+    document.getElementById('email-body-editor').addEventListener('input', function () {
+        if (this.textContent.trim() === '') setEditorContent('');
+    });
+
+    document.getElementById('email-body-editor').addEventListener('focus', function () {
+        var placeholder = this.dataset.placeholder;
+        if (this.textContent.trim() === placeholder) this.innerHTML = '';
+    });
+</script>
 </body>
 </html>

--- a/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
+++ b/RentACar.Web/Views/EmailServices/SendEmail/Compose.cshtml
@@ -280,18 +280,46 @@
 </div>
 
 <!-- Store Templates in JS for Fast Switching -->
-<script>
-    var sysTemplates = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.Templates));
-    var distributionLists = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.DistributionLists));
+<script id="templates-data" type="application/json">
+@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.Templates ?? new List<object>()))
+</script>
+<script id="distlists-data" type="application/json">
+@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(ViewBag.DistributionLists ?? new List<object>()))
 </script>
 
 <script>
+    // Global variables initialization
+    var sysTemplates = [];
+    var distributionLists = [];
+    
+    try {
+        var templatesDataEl = document.getElementById('templates-data');
+        if (templatesDataEl && templatesDataEl.textContent) {
+            sysTemplates = JSON.parse(templatesDataEl.textContent);
+        }
+    } catch (e) {
+        console.error('Failed to parse templates:', e);
+    }
+    
+    try {
+        var distListsDataEl = document.getElementById('distlists-data');
+        if (distListsDataEl && distListsDataEl.textContent) {
+            distributionLists = JSON.parse(distListsDataEl.textContent);
+        }
+    } catch (e) {
+        console.error('Failed to parse distribution lists:', e);
+    }
+    
     var currentMode = 'manual';
     var recipients = [];
     var selectedDistLists = [];
     var currentDraftId = 0;
     var attachmentFiles = [];
     var savedSelectionRange = null;
+    
+    // Log to verify templates are loaded
+    console.log('Templates loaded:', sysTemplates);
+    console.log('Distribution lists loaded:', distributionLists);
 
     function setMode(mode) {
             currentMode = mode;
@@ -381,15 +409,38 @@
 
         // Template Selection
         function onTemplateSelect(elem) {
-            var key = elem.value;
-            if(!key) return;
-            
-            var tmpl = sysTemplates.find(t => t.TemplateKey === key);
-            if(tmpl) {
-                // Populate editor
-                document.getElementById('email-subject').value = tmpl.Subject;
-                setEditorContent(tmpl.Body);
-                focusEditor();
+            try {
+                var key = elem.value;
+                console.log('Template selected:', key);
+                
+                if(!key) {
+                    console.log('No template key selected');
+                    return;
+                }
+                
+                // Check if sysTemplates is defined and is an array
+                if (typeof sysTemplates === 'undefined' || !Array.isArray(sysTemplates)) {
+                    console.error('sysTemplates is not defined or not an array:', sysTemplates);
+                    alert('Error: Templates data not loaded. Please refresh the page.');
+                    return;
+                }
+                
+                console.log('Available templates:', sysTemplates);
+                var tmpl = sysTemplates.find(t => t.TemplateKey === key);
+                
+                if(tmpl) {
+                    console.log('Found template:', tmpl);
+                    // Populate editor
+                    document.getElementById('email-subject').value = tmpl.Subject || '';
+                    setEditorContent(tmpl.Body || '');
+                    focusEditor();
+                } else {
+                    console.warn('Template not found for key:', key);
+                    alert('Template not found');
+                }
+            } catch (error) {
+                console.error('Error in onTemplateSelect:', error);
+                alert('An error occurred while selecting the template: ' + error.message);
             }
         }
         


### PR DESCRIPTION
### Motivation
- Repair multiple issues in the Email Composer so templates load into the editor, distribution list selections merge into recipients, attachments can be added, draft deletion works, and toolbar actions (e.g. lists/links) operate as expected.
- Ensure the server accepts multi-part form submissions for attachments and add endpoints to list/clear drafts so the UI can refresh and clear drafts.

### Description
- View updates: enhanced `Compose.cshtml` to populate the editor when selecting a template via `onTemplateSelect`/`setEditorContent`, added `data-placeholder` handling, switched the link toolbar button to call `insertLink`, and preserved editor selection for `execCmd` operations. 
- Attachments/UI: added an attachments picker, attachment list rendering and `FormData` wiring so files are included when sending (`triggerAttachmentPicker`, `handleAttachmentChange`, `renderAttachments`, etc.).
- Distribution lists and recipients: show selected lists as chips in the recipients area, synchronize modal checkbox selections with the composer, and update hidden fields via `updateHiddenInputs` and `syncDistListSelections`.
- Drafts & controller changes: added `id`/`data-draft-item` and `draft-count` in the UI, implemented client-side `refreshDrafts` and `clearAllDrafts`, switched send endpoint to accept form posts (`[FromForm]`) to support attachments, and added server endpoints `Drafts` and `DeleteAllDrafts` to list/clear drafts.
- Manager/repository changes: added `DeleteDraftsByUserIdAsync` to `IEmailDraftRepository` and `EmailDraftRepository`, and `DeleteAllDraftsAsync` to `EmailDraftManager` so server-side clearing of drafts is supported.

### Testing
- No automated tests were executed in this environment because `dotnet run --project RentACar.Web` could not be run due to `dotnet` not being available, so runtime/integration validation was not performed. }

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729008d2a483208c1e150a71a082af)