### PR TITLE
Add pickup pin for chauffeur bookings; fix schedule and tracking layouts

### DIFF
--- a/RentACar.Application/Managers/BookingManager.cs
+++ b/RentACar.Application/Managers/BookingManager.cs
@@ -209,16 +209,53 @@ namespace RentACar.Application.Managers
                 PickupAddress = requestDto.PickupAddress,
                 PickupDateTime = requestDto.PickupDateTime
             };
-            var coords = await _geocodingService.GeocodeAsync(booking.PickupAddress ?? "");
 
-            if (coords == null)
+            var requestLat = requestDto.PickupLatitude;
+            var requestLng = requestDto.PickupLongitude;
+
+            if (requestDto.HasDriver)
             {
-                _logger.LogWarning("Geocoding failed for pickup address: {Address}", booking.PickupAddress);
-                throw new InvalidOperationException("GEOCODING_FAILED");
-            }
+                if (requestLat.HasValue && requestLng.HasValue)
+                {
+                    booking.PickupLatitude = requestLat;
+                    booking.PickupLongitude = requestLng;
+                }
+                else if (!string.IsNullOrWhiteSpace(booking.PickupAddress))
+                {
+                    var coords = await _geocodingService.GeocodeAsync(booking.PickupAddress);
+                    if (coords == null)
+                    {
+                        _logger.LogWarning("Geocoding failed for pickup address: {Address}", booking.PickupAddress);
+                        throw new InvalidOperationException("GEOCODING_FAILED");
+                    }
 
-            booking.PickupLatitude = coords.Value.lat;
-            booking.PickupLongitude = coords.Value.lng;
+                    booking.PickupLatitude = coords.Value.lat;
+                    booking.PickupLongitude = coords.Value.lng;
+                }
+                else
+                {
+                    _logger.LogWarning("Pickup location missing for chauffeur booking.");
+                    throw new InvalidOperationException("GEOCODING_FAILED");
+                }
+            }
+            else if (requestLat.HasValue && requestLng.HasValue)
+            {
+                booking.PickupLatitude = requestLat;
+                booking.PickupLongitude = requestLng;
+            }
+            else if (!string.IsNullOrWhiteSpace(booking.PickupAddress))
+            {
+                var coords = await _geocodingService.GeocodeAsync(booking.PickupAddress);
+                if (coords != null)
+                {
+                    booking.PickupLatitude = coords.Value.lat;
+                    booking.PickupLongitude = coords.Value.lng;
+                }
+                else
+                {
+                    _logger.LogWarning("Geocoding skipped for pickup address: {Address}", booking.PickupAddress);
+                }
+            }
 
 
             // Save booking first to generate BookingId

--- a/RentACar.Web/Controllers/BookingController.cs
+++ b/RentACar.Web/Controllers/BookingController.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore;
 using RentACar.Web.Models;
 using System.Security.Claims;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace RentACar.Web.Controllers
 {
@@ -31,6 +32,7 @@ namespace RentACar.Web.Controllers
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IMapper _mapper;
         private readonly ILogger<BookingController> _logger;
+        private readonly IConfiguration _config;
 
         public BookingController(
             BookingManager bookingManager,
@@ -41,7 +43,8 @@ namespace RentACar.Web.Controllers
             EmployeeManager employeeManager,
             UserManager<IdentityUser> userManager,
             IMapper mapper,
-            ILogger<BookingController> logger)
+            ILogger<BookingController> logger,
+            IConfiguration config)
         {
             _bookingManager = bookingManager;
             _paymentManager = paymentManager;
@@ -52,6 +55,7 @@ namespace RentACar.Web.Controllers
             _userManager = userManager;
             _mapper = mapper;
             _logger = logger;
+            _config = config;
         }
 
         [HttpGet("~/Booking")]
@@ -73,6 +77,8 @@ namespace RentACar.Web.Controllers
                 ViewBag.EndDate = end.ToDateTime(TimeOnly.MinValue).ToString("yyyy-MM-dd");
                 ViewBag.CarId = carId.Value.ToString();
             }
+
+            ViewBag.GoogleMapsKey = _config["GOOGLE_MAPS_API_KEY"];
 
             return View("~/Views/ControlPanel/Booking/Add.cshtml", new BookingDto());
         }

--- a/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
+++ b/RentACar.Web/Views/ControlPanel/Booking/Add.cshtml
@@ -34,6 +34,18 @@
     <link rel="stylesheet" href="~/css/bookings.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet" />
+    <style>
+        .pickup-map {
+            height: 420px;
+            min-height: 280px;
+        }
+
+        @@media (max-width: 576px) {
+            .pickup-map {
+                height: 300px;
+            }
+        }
+    </style>
 </head>
 <body>
     @await Html.PartialAsync("_PopupNotifications")
@@ -93,6 +105,28 @@
                 <label class="form-label">Pickup Address</label>
                 <input type="text" class="form-control" id="PickupAddress" name="PickupAddress" placeholder="Enter pickup address" />
             </div>
+            <div id="pickupPinSection" class="mb-4" style="display:none;">
+                <h5 class="text-warning mb-2">Pickup Location (Pin)</h5>
+                <p class="text-muted small mb-3">
+                    Drop a pin to confirm pickup location for your chauffeur.
+                </p>
+                <div class="card bg-dark border border-secondary text-light p-3">
+                    <div class="d-flex flex-column flex-md-row gap-2 mb-3">
+                        <input type="text" id="pickupSearch" class="form-control" placeholder="Search location / address" />
+                        <button type="button" id="useMyLocation" class="btn btn-outline-warning">
+                            <i class="fas fa-location-crosshairs me-1"></i>
+                            Use my current location
+                        </button>
+                    </div>
+                    <div id="pickupMap" class="pickup-map rounded border border-secondary"></div>
+                    <div class="mt-3 d-flex flex-column flex-md-row justify-content-between gap-2 small">
+                        <span>Lat/Lng: <strong id="pickupLatLng">Not set</strong></span>
+                        <span id="pickupConfirm" class="text-warning">Location not confirmed</span>
+                    </div>
+                </div>
+                <input type="hidden" id="PickupLatitude" name="PickupLatitude" />
+                <input type="hidden" id="PickupLongitude" name="PickupLongitude" />
+            </div>
             <div class="mb-3">
                 <label class="form-label">Pickup Date & Time</label>
                 <input type="datetime-local" class="form-control" id="PickupDateTime" name="PickupDateTime" />
@@ -133,6 +167,8 @@
             const driverOption = document.querySelector('input[name="driverOption"]:checked')?.value ?? 'self';
             const hasDriver = driverOption === 'with';
             const driverDailyFee = parseFloat(form.dataset.driverDailyFee || '0');
+            const pickupLatitude = document.getElementById('PickupLatitude')?.value;
+            const pickupLongitude = document.getElementById('PickupLongitude')?.value;
             const data = {
                 carId: parseInt(document.getElementById('CarId').value),
                 startdate: document.getElementById('Startdate').value,
@@ -147,6 +183,11 @@
 
             if (customerIdInput) {
                 data.customerId = parseInt(customerIdInput.value);
+            }
+
+            if (pickupLatitude && pickupLongitude) {
+                data.pickupLatitude = parseFloat(pickupLatitude);
+                data.pickupLongitude = parseFloat(pickupLongitude);
             }
 
             try {
@@ -185,6 +226,17 @@
             const endInput = document.getElementById('Enddate');
             const driverCostEl = document.getElementById('driverCost');
             const options = document.querySelectorAll('input[name="driverOption"]');
+            const pickupPinSection = document.getElementById('pickupPinSection');
+            const pickupConfirm = document.getElementById('pickupConfirm');
+            const pickupLatLng = document.getElementById('pickupLatLng');
+            const pickupLatInput = document.getElementById('PickupLatitude');
+            const pickupLngInput = document.getElementById('PickupLongitude');
+            const pickupSearch = document.getElementById('pickupSearch');
+            const useMyLocationBtn = document.getElementById('useMyLocation');
+            let pickupMap;
+            let pickupMarker;
+            let searchBox;
+            let mapReady = false;
 
             function calculateDays() {
                 const start = new Date(startInput.value);
@@ -202,11 +254,129 @@
                 driverCostEl.textContent = `$${cost.toFixed(2)}`;
             }
 
+            function updatePickupDisplay(latLng) {
+                if (!latLng) {
+                    pickupLatLng.textContent = 'Not set';
+                    pickupConfirm.textContent = 'Location not confirmed';
+                    pickupConfirm.classList.remove('text-success');
+                    pickupConfirm.classList.add('text-warning');
+                    return;
+                }
+
+                pickupLatInput.value = latLng.lat.toFixed(6);
+                pickupLngInput.value = latLng.lng.toFixed(6);
+                pickupLatLng.textContent = `${latLng.lat.toFixed(6)}, ${latLng.lng.toFixed(6)}`;
+                pickupConfirm.textContent = 'Location confirmed';
+                pickupConfirm.classList.remove('text-warning');
+                pickupConfirm.classList.add('text-success');
+            }
+
+            function setPickupMarker(latLng, shouldCenter = true) {
+                if (!pickupMap || !pickupMarker || !latLng) return;
+                pickupMarker.setPosition(latLng);
+                if (shouldCenter) {
+                    pickupMap.setCenter(latLng);
+                }
+                updatePickupDisplay(latLng);
+            }
+
+            function initPickupMap() {
+                if (mapReady || typeof google === 'undefined' || !pickupPinSection) return;
+                const defaultCenter = { lat: 33.8938, lng: 35.5018 };
+                pickupMap = new google.maps.Map(document.getElementById('pickupMap'), {
+                    center: defaultCenter,
+                    zoom: 13,
+                    disableDefaultUI: true,
+                    gestureHandling: 'greedy'
+                });
+
+                pickupMarker = new google.maps.Marker({
+                    position: defaultCenter,
+                    map: pickupMap,
+                    draggable: true,
+                    title: 'Pickup location'
+                });
+
+                pickupMap.addListener('click', (event) => {
+                    if (!event?.latLng) return;
+                    setPickupMarker({ lat: event.latLng.lat(), lng: event.latLng.lng() });
+                });
+
+                pickupMarker.addListener('dragend', () => {
+                    const pos = pickupMarker.getPosition();
+                    if (pos) {
+                        setPickupMarker({ lat: pos.lat(), lng: pos.lng() }, false);
+                    }
+                });
+
+                if (pickupSearch && google.maps.places) {
+                    searchBox = new google.maps.places.SearchBox(pickupSearch);
+                    pickupSearch.addEventListener('keydown', (event) => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                        }
+                    });
+                    searchBox.addListener('places_changed', () => {
+                        const places = searchBox.getPlaces();
+                        if (!places || !places.length) return;
+                        const place = places[0];
+                        if (!place.geometry || !place.geometry.location) return;
+                        setPickupMarker({
+                            lat: place.geometry.location.lat(),
+                            lng: place.geometry.location.lng()
+                        });
+                    });
+                }
+
+                mapReady = true;
+                updatePickupDisplay(null);
+            }
+
+            function togglePickupSection() {
+                const hasDriver = document.querySelector('input[name="driverOption"]:checked')?.value === 'with';
+                pickupPinSection.style.display = hasDriver ? 'block' : 'none';
+                if (hasDriver && window.google) {
+                    initPickupMap();
+                }
+            }
+
+            if (useMyLocationBtn) {
+                useMyLocationBtn.addEventListener('click', () => {
+                    if (!navigator.geolocation) {
+                        showPopup?.('Geolocation is not supported by your browser.', 'error');
+                        return;
+                    }
+
+                    navigator.geolocation.getCurrentPosition(
+                        (pos) => {
+                            const coords = {
+                                lat: pos.coords.latitude,
+                                lng: pos.coords.longitude
+                            };
+                            setPickupMarker(coords);
+                        },
+                        () => {
+                            showPopup?.('Unable to access your location. Please drop a pin manually.', 'error');
+                        }
+                    );
+                });
+            }
+
             options.forEach(option => option.addEventListener('change', updateDriverCost));
             startInput.addEventListener('change', updateDriverCost);
             endInput.addEventListener('change', updateDriverCost);
             updateDriverCost();
+            togglePickupSection();
+            options.forEach(option => option.addEventListener('change', togglePickupSection));
+
+            window.initPickupMap = initPickupMap;
         })();
     </script>
+    @if (!string.IsNullOrWhiteSpace(ViewBag.GoogleMapsKey))
+    {
+        <script async defer
+                src="https://maps.googleapis.com/maps/api/js?key=@ViewBag.GoogleMapsKey&libraries=places&callback=initPickupMap">
+        </script>
+    }
 </body>
 </html>

--- a/RentACar.Web/Views/DriverPortal/Schedule.cshtml
+++ b/RentACar.Web/Views/DriverPortal/Schedule.cshtml
@@ -19,16 +19,16 @@
     }
 </style>
 
-<div class="flex flex-col h-screen overflow-hidden">
-    <div class="flex flex-1 overflow-hidden">
-        <main class="flex-1 flex overflow-hidden">
-            <div class="flex-1 flex flex-col p-8 overflow-y-auto">
+<div class="flex flex-col min-h-screen">
+    <div class="flex flex-1">
+        <main class="flex-1 flex">
+            <div class="flex-1 flex flex-col p-6 md:p-8 overflow-y-auto">
                 <div class="flex flex-col gap-1 mb-8">
                     <h1 class="text-4xl font-black tracking-tight text-white">Driver Calendar &amp; Schedule</h1>
                     <p class="text-white/50 text-base">Manage availability blocks for @Model.DriverName.</p>
                 </div>
 
-                <div class="flex-1 glass-darker rounded-2xl overflow-hidden border border-white/5 flex flex-col">
+                <div class="flex-1 glass-darker rounded-2xl border border-white/5 flex flex-col min-h-[600px] overflow-auto">
                     <div class="grid grid-cols-7 border-b border-white/5 bg-white/5">
                         <div class="p-3 text-center text-xs font-bold text-white/30 uppercase tracking-widest">Sun</div>
                         <div class="p-3 text-center text-xs font-bold text-white/30 uppercase tracking-widest">Mon</div>

--- a/RentACar.Web/Views/Tracking/CustomerLive.cshtml
+++ b/RentACar.Web/Views/Tracking/CustomerLive.cshtml
@@ -41,20 +41,16 @@
     }
 </style>
 
-<main class="relative h-[calc(100vh-120px)] w-full overflow-hidden">
-
-    <!-- GOOGLE MAP -->
-    <div id="map" class="absolute inset-0"></div>
-
-    <!-- TOP INFO CARD -->
-    <div class="absolute top-24 left-1/2 -translate-x-1/2 w-full max-w-[520px] px-4 z-10">
-        <div class="glass-panel rounded-xl p-4 flex items-center justify-between shadow-2xl">
+<main class="w-full px-4 md:px-8 py-8">
+    <div class="max-w-6xl mx-auto flex flex-col gap-6">
+        <!-- TOP INFO CARD -->
+        <div class="glass-panel rounded-2xl p-4 md:p-5 flex flex-col md:flex-row md:items-center justify-between gap-4 shadow-2xl">
             <div class="flex items-center gap-4">
                 <div class="flex flex-col">
                     <p class="text-[10px] font-bold uppercase tracking-widest text-primary/80">
                         Track Your Driver
                     </p>
-                    <h2 class="text-lg font-bold leading-none mt-0.5">
+                    <h2 class="text-lg md:text-xl font-bold leading-none mt-0.5">
                         @Model.DriverName
                     </h2>
                     <div class="flex items-center gap-2 mt-1">
@@ -70,43 +66,50 @@
                 Booking #@Model.BookingId
             </div>
         </div>
-    </div>
 
-    <!-- LEFT STATUS -->
-    <div class="absolute left-6 bottom-24 flex flex-col gap-4 z-10">
-        <div class="glass-panel rounded-xl p-4 min-w-[180px]">
-            <div class="flex items-center gap-3 mb-1">
-                <div class="pulse-dot"></div>
-                <p class="text-xs font-bold uppercase tracking-widest text-white/50">Status</p>
+        <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+            <!-- STATUS COLUMN -->
+            <div class="flex flex-col gap-4">
+                <div class="glass-panel rounded-xl p-4">
+                    <div class="flex items-center gap-3 mb-1">
+                        <div class="pulse-dot"></div>
+                        <p class="text-xs font-bold uppercase tracking-widest text-white/50">Status</p>
+                    </div>
+                    <p class="text-xl font-bold text-primary" id="trackingStatus">
+                        Live Tracking ON
+                    </p>
+                </div>
+
+                <div class="glass-panel rounded-xl p-4">
+                    <p class="text-xs font-bold uppercase tracking-widest text-white/50 mb-1">
+                        Last Ping
+                    </p>
+                    <span class="text-sm font-bold" id="lastPing">
+                        @Model.LastPingAt?.ToLocalTime().ToString("HH:mm:ss")
+                    </span>
+
+                    <div class="mt-2 text-xs text-white/40">
+                        <span id="lastCoordinates">
+                            @Model.LastLatitude?.ToString("F4"),
+                            @Model.LastLongitude?.ToString("F4")
+                        </span>
+                    </div>
+                </div>
             </div>
-            <p class="text-xl font-bold text-primary" id="trackingStatus">
-                Live Tracking ON
-            </p>
+
+            <!-- MAP CARD -->
+            <div class="glass-panel rounded-2xl border border-primary/20 overflow-hidden lg:col-span-3">
+                <div id="map" class="h-[320px] sm:h-[420px] lg:h-[580px]"></div>
+            </div>
         </div>
 
-        <div class="glass-panel rounded-xl p-4 min-w-[180px]">
-            <p class="text-xs font-bold uppercase tracking-widest text-white/50 mb-1">
-                Last Ping
-            </p>
-            <span class="text-sm font-bold" id="lastPing">
-                @Model.LastPingAt?.ToLocalTime().ToString("HH:mm:ss")
+        <!-- FOOTER -->
+        <footer class="glass-panel rounded-xl py-3 text-center">
+            <span class="text-white/40 text-[10px] uppercase tracking-[0.2em]">
+                Location sharing is active during your booking
             </span>
-
-            <div class="mt-2 text-xs text-white/40">
-                <span id="lastCoordinates">
-                    @Model.LastLatitude?.ToString("F4"),
-                    @Model.LastLongitude?.ToString("F4")
-                </span>
-            </div>
-        </div>
+        </footer>
     </div>
-
-    <!-- FOOTER -->
-    <footer class="absolute bottom-0 left-0 right-0 py-4 glass-panel text-center z-10">
-        <span class="text-white/40 text-[10px] uppercase tracking-[0.2em]">
-            Location sharing is active during your booking
-        </span>
-    </footer>
 </main>
 
 <!-- SIGNALR -->
@@ -118,9 +121,9 @@
     function initMap() {
         const driverLat = @(Model.LastLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "33.8938");
         const driverLng = @(Model.LastLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "35.5018");
-
-        const pickupLat = @(Model.PickupLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "33.8938");
-        const pickupLng = @(Model.PickupLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "35.5018");
+        const pickupLat = @(Model.PickupLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? Model.LastLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "33.8938");
+        const pickupLng = @(Model.PickupLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? Model.LastLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "35.5018");
+        const hasPickup = @(Model.PickupLatitude.HasValue && Model.PickupLongitude.HasValue ? "true" : "false");
 
         map = new google.maps.Map(document.getElementById("map"), {
             center: { lat: Number(driverLat), lng: Number(driverLng) },
@@ -138,7 +141,7 @@
         pickupMarker = new google.maps.Marker({
             position: { lat: Number(pickupLat), lng: Number(pickupLng) },
             map,
-            title: "Pickup"
+            title: hasPickup ? "Pickup" : "Pickup (estimated)"
         });
     }
 
@@ -161,6 +164,10 @@
 
             if (map && driverMarker) {
                 driverMarker.setPosition(pos);
+                const bounds = map.getBounds();
+                if (bounds && !bounds.contains(pos)) {
+                    map.panTo(pos);
+                }
             }
 
             statusEl.textContent = "Live Tracking ON";


### PR DESCRIPTION
### Motivation
- Enable customers to specify an exact pickup location by dropping a pin when `HasDriver` (private chauffeur) is selected so bookings can save `PickupLatitude`/`PickupLongitude` without relying on geocoding.
- Ensure backend booking creation prefers explicit coordinates and only falls back to geocoding, returning a validation-friendly error when chauffeur bookings lack location data.
- Fix layout issues that caused the driver calendar to be vertically cut off and make the customer live tracking map render inside a contained card (not full-screen) while keeping the Tailwind dark/gold theme.

### Description
- Added a pickup pin UI to the booking add form: new map card, search box, "Use my current location" button, draggable marker, read-only lat/lng preview, and hidden inputs `PickupLatitude`/`PickupLongitude` in `RentACar.Web/Views/ControlPanel/Booking/Add.cshtml`, plus Google Maps `places` library loading when `ViewBag.GoogleMapsKey` is present. 
- Wired client submission to include `pickupLatitude`/`pickupLongitude` when set so the API receives pin coordinates from the form. 
- Updated booking creation logic in `RentACar.Application/Managers/BookingManager.cs` to: prefer `MakeBookingRequestDto.PickupLatitude`/`PickupLongitude` when present for chauffeur bookings, otherwise attempt geocoding, and throw a `GEOCODING_FAILED` flow-controlled exception when a chauffeur booking cannot be located (so the controller returns a clear validation message). 
- Exposed `GOOGLE_MAPS_API_KEY` to the add booking view by injecting `IConfiguration` in `RentACar.Web/Controllers/BookingController.cs` and setting `ViewBag.GoogleMapsKey`, keeping the API key out of view markup. 
- Fixed driver schedule layout in `RentACar.Web/Views/DriverPortal/Schedule.cshtml` by removing nested `h-screen/overflow-hidden`, adding `min-h-[600px]` and `overflow-auto` to the calendar container so the full 7×5 grid is visible and scrollable. 
- Converted customer live tracking in `RentACar.Web/Views/Tracking/CustomerLive.cshtml` to a contained card-based layout with controlled map heights (`h-[320px]` / `sm:h-[420px]` / `lg:h-[580px]`), preserved driver/pickup markers, and added a small pan-to-driver-if-out-of-view behavior on SignalR updates. 

### Testing
- No automated tests were executed in this change (no CI/unit tests were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a04c6fc5c8320b343008916ea9e2e)