### PR TITLE
Add trips module with driver workflow and live tracking

### DIFF
--- a/RentACar.Application/DTOs/TripDto.cs
+++ b/RentACar.Application/DTOs/TripDto.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace RentACar.Application.DTOs;
+
+public class TripDto
+{
+    public int TripId { get; set; }
+    public int BookingId { get; set; }
+    public int? DriverId { get; set; }
+    public string TripStatus { get; set; } = string.Empty;
+    public DateTime? StartedAt { get; set; }
+    public DateTime? ArrivedAt { get; set; }
+    public DateTime? TripStartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public DateTime? CancelledAt { get; set; }
+    public string? CancelReason { get; set; }
+    public decimal? LastDriverLatitude { get; set; }
+    public decimal? LastDriverLongitude { get; set; }
+    public DateTime? LastLocationUpdatedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public enum TripActionError
+{
+    None,
+    NotFound,
+    Forbidden,
+    InvalidTransition,
+    TerminalState
+}
+
+public class TripActionResult
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public TripDto? Trip { get; set; }
+    public TripActionError Error { get; set; }
+
+    public static TripActionResult SuccessResult(TripDto trip, string message = "Success")
+        => new() { Success = true, Message = message, Trip = trip, Error = TripActionError.None };
+
+    public static TripActionResult Failure(TripActionError error, string message)
+        => new() { Success = false, Message = message, Trip = null, Error = error };
+}

--- a/RentACar.Application/Managers/TripManager.cs
+++ b/RentACar.Application/Managers/TripManager.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using RentACar.Application.DTOs;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+
+namespace RentACar.Application.Managers;
+
+public class TripManager
+{
+    private readonly ITripRepository _tripRepository;
+    private readonly IBookingRepository _bookingRepository;
+    private readonly IMapper _mapper;
+    private readonly AuditLogManager _auditLogManager;
+
+    private static readonly Dictionary<TripStatus, TripStatus[]> AllowedTransitions = new()
+    {
+        { TripStatus.Assigned, new[] { TripStatus.OnTheWay, TripStatus.Cancelled } },
+        { TripStatus.OnTheWay, new[] { TripStatus.Arrived, TripStatus.Cancelled } },
+        { TripStatus.Arrived, new[] { TripStatus.InTrip, TripStatus.Cancelled } },
+        { TripStatus.InTrip, new[] { TripStatus.Completed, TripStatus.Cancelled } }
+    };
+
+    public TripManager(
+        ITripRepository tripRepository,
+        IBookingRepository bookingRepository,
+        IMapper mapper,
+        AuditLogManager auditLogManager)
+    {
+        _tripRepository = tripRepository;
+        _bookingRepository = bookingRepository;
+        _mapper = mapper;
+        _auditLogManager = auditLogManager;
+    }
+
+    public async Task<List<TripDto>> GetTripsByDriverIdAsync(int driverId)
+    {
+        var trips = await _tripRepository.GetTripsByDriverIdAsync(driverId);
+        return _mapper.Map<List<TripDto>>(trips);
+    }
+
+    public async Task<TripActionResult> StartTrackingAsync(int bookingId, int driverId)
+    {
+        return await ChangeStatusAsync(bookingId, driverId, TripStatus.OnTheWay, "Trip.StartTracking");
+    }
+
+    public async Task<TripActionResult> MarkArrivedAsync(int bookingId, int driverId)
+    {
+        return await ChangeStatusAsync(bookingId, driverId, TripStatus.Arrived, "Trip.Arrived");
+    }
+
+    public async Task<TripActionResult> StartTripAsync(int bookingId, int driverId)
+    {
+        return await ChangeStatusAsync(bookingId, driverId, TripStatus.InTrip, "Trip.Started");
+    }
+
+    public async Task<TripActionResult> CompleteTripAsync(int bookingId, int driverId)
+    {
+        return await ChangeStatusAsync(bookingId, driverId, TripStatus.Completed, "Trip.Completed");
+    }
+
+    public async Task<TripActionResult> CancelTripAsync(int bookingId, int driverId, string? reason)
+    {
+        var (trip, booking, errorResult) = await LoadTripAsync(bookingId, driverId, createIfMissing: true);
+        if (errorResult != null)
+        {
+            return errorResult;
+        }
+
+        if (trip == null || booking == null)
+        {
+            return TripActionResult.Failure(TripActionError.NotFound, "Trip not found.");
+        }
+
+        if (IsTerminal(trip.TripStatus))
+        {
+            return TripActionResult.Failure(TripActionError.TerminalState, "Trip is already completed or cancelled.");
+        }
+
+        var now = DateTime.UtcNow;
+        trip.TripStatus = TripStatus.Cancelled;
+        trip.CancelledAt = now;
+        trip.CancelReason = string.IsNullOrWhiteSpace(reason) ? trip.CancelReason : reason;
+        trip.UpdatedAt = now;
+
+        await _tripRepository.UpdateTripAsync(trip);
+        await _auditLogManager.LogEventAsync("Trip.Cancelled", "Trip", trip.TripId.ToString(),
+            $"Trip cancelled for booking {bookingId}", null, "Success");
+
+        return TripActionResult.SuccessResult(_mapper.Map<TripDto>(trip), "Trip cancelled.");
+    }
+
+    public async Task<TripActionResult> UpdateDriverLocationAsync(int bookingId, int driverId, decimal latitude, decimal longitude, DateTime? timestamp)
+    {
+        var (trip, booking, errorResult) = await LoadTripAsync(bookingId, driverId, createIfMissing: true);
+        if (errorResult != null)
+        {
+            return errorResult;
+        }
+
+        if (trip == null || booking == null)
+        {
+            return TripActionResult.Failure(TripActionError.NotFound, "Trip not found.");
+        }
+
+        if (IsTerminal(trip.TripStatus))
+        {
+            return TripActionResult.Failure(TripActionError.TerminalState, "Trip is already completed or cancelled.");
+        }
+
+        var now = timestamp == default ? DateTime.UtcNow : timestamp.Value.ToUniversalTime();
+        trip.LastDriverLatitude = latitude;
+        trip.LastDriverLongitude = longitude;
+        trip.LastLocationUpdatedAt = now;
+        trip.UpdatedAt = DateTime.UtcNow;
+
+        await _tripRepository.UpdateTripAsync(trip);
+
+        return TripActionResult.SuccessResult(_mapper.Map<TripDto>(trip), "Location updated.");
+    }
+
+    private async Task<TripActionResult> ChangeStatusAsync(int bookingId, int driverId, TripStatus nextStatus, string auditAction)
+    {
+        var (trip, booking, errorResult) = await LoadTripAsync(bookingId, driverId, createIfMissing: true);
+        if (errorResult != null)
+        {
+            return errorResult;
+        }
+
+        if (trip == null || booking == null)
+        {
+            return TripActionResult.Failure(TripActionError.NotFound, "Trip not found.");
+        }
+
+        if (IsTerminal(trip.TripStatus))
+        {
+            return TripActionResult.Failure(TripActionError.TerminalState, "Trip is already completed or cancelled.");
+        }
+
+        if (trip.TripStatus != nextStatus && !IsValidTransition(trip.TripStatus, nextStatus))
+        {
+            return TripActionResult.Failure(TripActionError.InvalidTransition,
+                $"Cannot change trip status from {trip.TripStatus} to {nextStatus}.");
+        }
+
+        var now = DateTime.UtcNow;
+        if (trip.TripStatus != nextStatus)
+        {
+            trip.TripStatus = nextStatus;
+        }
+
+        switch (nextStatus)
+        {
+            case TripStatus.OnTheWay:
+                trip.StartedAt ??= now;
+                break;
+            case TripStatus.Arrived:
+                trip.ArrivedAt ??= now;
+                break;
+            case TripStatus.InTrip:
+                trip.TripStartedAt ??= now;
+                break;
+            case TripStatus.Completed:
+                trip.CompletedAt = now;
+                break;
+        }
+
+        trip.UpdatedAt = now;
+
+        await _tripRepository.UpdateTripAsync(trip);
+        await _auditLogManager.LogEventAsync(auditAction, "Trip", trip.TripId.ToString(),
+            $"Trip status changed to {trip.TripStatus} for booking {bookingId}", null, "Success");
+
+        return TripActionResult.SuccessResult(_mapper.Map<TripDto>(trip), "Trip updated.");
+    }
+
+    private async Task<(Trip? trip, Booking? booking, TripActionResult? errorResult)> LoadTripAsync(int bookingId, int driverId, bool createIfMissing)
+    {
+        var booking = await _bookingRepository.GetBookingByIdAsync(bookingId);
+        if (booking == null)
+        {
+            return (null, null, TripActionResult.Failure(TripActionError.NotFound, "Booking not found."));
+        }
+
+        if (!booking.DriverId.HasValue || booking.DriverId.Value != driverId)
+        {
+            return (null, booking, TripActionResult.Failure(TripActionError.Forbidden, "You are not assigned to this booking."));
+        }
+
+        var trip = await _tripRepository.GetTripByBookingIdAsync(bookingId);
+        if (trip == null && createIfMissing)
+        {
+            var now = DateTime.UtcNow;
+            trip = new Trip
+            {
+                BookingId = bookingId,
+                DriverId = booking.DriverId,
+                TripStatus = TripStatus.Assigned,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            await _tripRepository.CreateTripAsync(trip);
+        }
+
+        if (trip != null && trip.DriverId == null)
+        {
+            trip.DriverId = booking.DriverId;
+            trip.UpdatedAt = DateTime.UtcNow;
+            await _tripRepository.UpdateTripAsync(trip);
+        }
+
+        return (trip, booking, null);
+    }
+
+    private static bool IsValidTransition(TripStatus current, TripStatus next)
+    {
+        return AllowedTransitions.TryGetValue(current, out var allowed) && allowed.Contains(next);
+    }
+
+    private static bool IsTerminal(TripStatus status)
+    {
+        return status == TripStatus.Completed || status == TripStatus.Cancelled;
+    }
+}
+
+public class TripProfile : Profile
+{
+    public TripProfile()
+    {
+        CreateMap<Trip, TripDto>()
+            .ForMember(dest => dest.TripStatus, opt => opt.MapFrom(src => src.TripStatus.ToString()));
+    }
+}

--- a/RentACar.Core/Entities/Booking.cs
+++ b/RentACar.Core/Entities/Booking.cs
@@ -90,5 +90,8 @@ public partial class Booking
     [InverseProperty("Booking")]
     public virtual ICollection<DriverLocationPing> DriverLocationPings { get; set; } = new List<DriverLocationPing>();
 
+    [InverseProperty("Booking")]
+    public virtual Trip? Trip { get; set; }
+
     public virtual Payment? Payment { get; set; }
 }

--- a/RentACar.Core/Entities/Driver.cs
+++ b/RentACar.Core/Entities/Driver.cs
@@ -77,4 +77,7 @@ public partial class Driver
 
     [InverseProperty("Driver")]
     public virtual ICollection<DriverLocationPing> LocationPings { get; set; } = new List<DriverLocationPing>();
+
+    [InverseProperty("Driver")]
+    public virtual ICollection<Trip> Trips { get; set; } = new List<Trip>();
 }

--- a/RentACar.Core/Entities/Trip.cs
+++ b/RentACar.Core/Entities/Trip.cs
@@ -1,0 +1,64 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RentACar.Core.Entities;
+
+[Table("Trips")]
+public class Trip
+{
+    [Key]
+    [Column("tripID")]
+    public int TripId { get; set; }
+
+    [Column("bookingID")]
+    public int BookingId { get; set; }
+
+    [Column("driverID")]
+    public int? DriverId { get; set; }
+
+    [Column("tripStatus")]
+    public TripStatus TripStatus { get; set; } = TripStatus.Assigned;
+
+    [Column("startedAt")]
+    public DateTime? StartedAt { get; set; }
+
+    [Column("arrivedAt")]
+    public DateTime? ArrivedAt { get; set; }
+
+    [Column("tripStartedAt")]
+    public DateTime? TripStartedAt { get; set; }
+
+    [Column("completedAt")]
+    public DateTime? CompletedAt { get; set; }
+
+    [Column("cancelledAt")]
+    public DateTime? CancelledAt { get; set; }
+
+    [Column("cancelReason")]
+    [StringLength(500)]
+    public string? CancelReason { get; set; }
+
+    [Column("lastDriverLatitude", TypeName = "decimal(9, 6)")]
+    public decimal? LastDriverLatitude { get; set; }
+
+    [Column("lastDriverLongitude", TypeName = "decimal(9, 6)")]
+    public decimal? LastDriverLongitude { get; set; }
+
+    [Column("lastLocationUpdatedAt")]
+    public DateTime? LastLocationUpdatedAt { get; set; }
+
+    [Column("createdAt")]
+    public DateTime CreatedAt { get; set; }
+
+    [Column("updatedAt")]
+    public DateTime UpdatedAt { get; set; }
+
+    [ForeignKey("BookingId")]
+    [InverseProperty("Trip")]
+    public virtual Booking Booking { get; set; } = null!;
+
+    [ForeignKey("DriverId")]
+    [InverseProperty("Trips")]
+    public virtual Driver? Driver { get; set; }
+}

--- a/RentACar.Core/Entities/TripStatus.cs
+++ b/RentACar.Core/Entities/TripStatus.cs
@@ -1,0 +1,11 @@
+namespace RentACar.Core.Entities;
+
+public enum TripStatus
+{
+    Assigned = 0,
+    OnTheWay = 1,
+    Arrived = 2,
+    InTrip = 3,
+    Completed = 4,
+    Cancelled = 5
+}

--- a/RentACar.Core/Repositories/ITripRepository.cs
+++ b/RentACar.Core/Repositories/ITripRepository.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RentACar.Core.Entities;
+
+namespace RentACar.Core.Repositories;
+
+public interface ITripRepository
+{
+    Task<Trip?> GetTripByIdAsync(int tripId);
+    Task<Trip?> GetTripByBookingIdAsync(int bookingId);
+    Task<List<Trip>> GetTripsByDriverIdAsync(int driverId);
+    Task<Trip> CreateTripAsync(Trip trip);
+    Task UpdateTripAsync(Trip trip);
+}

--- a/RentACar.Infrastructure/Data/RentACarDbContext.cs
+++ b/RentACar.Infrastructure/Data/RentACarDbContext.cs
@@ -41,6 +41,7 @@ public partial class RentACarDbContext : DbContext
     public virtual DbSet<Payment> Payments { get; set; }
     public virtual DbSet<PaymentMethod> PaymentMethods { get; set; }
     public virtual DbSet<Promocode> Promocodes { get; set; }
+    public virtual DbSet<Trip> Trips { get; set; }
     public virtual DbSet<AuditLog> AuditLogs { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -180,6 +181,26 @@ public partial class RentACarDbContext : DbContext
                 .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade)
                 .HasConstraintName("FK_Payments_Bookings");
+        });
+
+        modelBuilder.Entity<Trip>(entity =>
+        {
+            entity.HasIndex(e => e.BookingId).IsUnique();
+
+            entity.Property(e => e.TripStatus)
+                .HasConversion<string>()
+                .HasMaxLength(30);
+
+            entity.HasOne(d => d.Booking)
+                .WithOne(p => p.Trip)
+                .HasForeignKey<Trip>(d => d.BookingId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("FK_Trips_Bookings");
+
+            entity.HasOne(d => d.Driver)
+                .WithMany(p => p.Trips)
+                .HasForeignKey(d => d.DriverId)
+                .HasConstraintName("FK_Trips_Drivers");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/RentACar.Infrastructure/Data/Repository/TripRepository.cs
+++ b/RentACar.Infrastructure/Data/Repository/TripRepository.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RentACar.Core.Entities;
+using RentACar.Core.Repositories;
+
+namespace RentACar.Infrastructure.Data.Repository;
+
+public class TripRepository : ITripRepository
+{
+    private readonly RentACarDbContext _dbContext;
+
+    public TripRepository(RentACarDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Trip?> GetTripByIdAsync(int tripId)
+    {
+        return await _dbContext.Trips
+            .Include(t => t.Booking)
+            .Include(t => t.Driver)
+            .FirstOrDefaultAsync(t => t.TripId == tripId);
+    }
+
+    public async Task<Trip?> GetTripByBookingIdAsync(int bookingId)
+    {
+        return await _dbContext.Trips
+            .Include(t => t.Booking)
+            .Include(t => t.Driver)
+            .FirstOrDefaultAsync(t => t.BookingId == bookingId);
+    }
+
+    public async Task<List<Trip>> GetTripsByDriverIdAsync(int driverId)
+    {
+        return await _dbContext.Trips
+            .AsNoTracking()
+            .Include(t => t.Booking)
+            .Include(t => t.Driver)
+            .Where(t => t.DriverId == driverId)
+            .ToListAsync();
+    }
+
+    public async Task<Trip> CreateTripAsync(Trip trip)
+    {
+        _dbContext.Trips.Add(trip);
+        await _dbContext.SaveChangesAsync();
+        return trip;
+    }
+
+    public async Task UpdateTripAsync(Trip trip)
+    {
+        _dbContext.Entry(trip).State = EntityState.Modified;
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/RentACar.Web/Controllers/Api/DriverLocationController.cs
+++ b/RentACar.Web/Controllers/Api/DriverLocationController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
+using RentACar.Application.Managers;
 using RentACar.Core.Entities;
 using RentACar.Core.Repositories;
 using RentACar.Infrastructure.Data;
@@ -20,6 +21,7 @@ public class DriverLocationController : ControllerBase
 {
     private readonly IDriverRepository _driverRepository;
     private readonly IBookingRepository _bookingRepository;
+    private readonly TripManager _tripManager;
     private readonly RentACarDbContext _dbContext;
     private readonly IHubContext<DriverTrackingHub> _hubContext;
     private readonly UserManager<IdentityUser> _userManager;
@@ -27,12 +29,14 @@ public class DriverLocationController : ControllerBase
     public DriverLocationController(
         IDriverRepository driverRepository,
         IBookingRepository bookingRepository,
+        TripManager tripManager,
         RentACarDbContext dbContext,
         IHubContext<DriverTrackingHub> hubContext,
         UserManager<IdentityUser> userManager)
     {
         _driverRepository = driverRepository;
         _bookingRepository = bookingRepository;
+        _tripManager = tripManager;
         _dbContext = dbContext;
         _hubContext = hubContext;
         _userManager = userManager;
@@ -81,6 +85,17 @@ public class DriverLocationController : ControllerBase
             BatteryPercent = request.Battery,
             CreatedAt = DateTime.UtcNow
         };
+
+        var tripResult = await _tripManager.UpdateDriverLocationAsync(
+            booking.BookingId,
+            driver.DriverId,
+            request.Latitude,
+            request.Longitude,
+            DateTime.UtcNow);
+        if (!tripResult.Success)
+        {
+            return BadRequest(tripResult.Message);
+        }
 
         _dbContext.DriverLocationPings.Add(ping);
         await _dbContext.SaveChangesAsync();

--- a/RentACar.Web/Controllers/DriverPortalController.cs
+++ b/RentACar.Web/Controllers/DriverPortalController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -18,7 +19,7 @@ public class DriverPortalController : Controller
     private readonly DriverManager _driverManager;
     private readonly BookingManager _bookingManager;
     private readonly CustomerManager _customerManager;
-    private readonly CarManager _carManager;
+    private readonly TripManager _tripManager;
     private readonly UserManager<IdentityUser> _userManager;
     private readonly RentACarDbContext _dbContext;
     private readonly IConfiguration _config;
@@ -27,7 +28,7 @@ public class DriverPortalController : Controller
         DriverManager driverManager,
         BookingManager bookingManager,
         CustomerManager customerManager,
-        CarManager carManager,
+        TripManager tripManager,
         UserManager<IdentityUser> userManager,
         RentACarDbContext dbContext,
         IConfiguration config)
@@ -35,7 +36,7 @@ public class DriverPortalController : Controller
         _driverManager = driverManager;
         _bookingManager = bookingManager;
         _customerManager = customerManager;
-        _carManager = carManager;
+        _tripManager = tripManager;
         _userManager = userManager;
         _dbContext = dbContext;
         _config = config;
@@ -53,6 +54,9 @@ public class DriverPortalController : Controller
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
 
         var todayBookings = await (from booking in _dbContext.Bookings.AsNoTracking()
+            join trip in _dbContext.Trips.AsNoTracking()
+                on booking.BookingId equals trip.BookingId into tripGroup
+            from trip in tripGroup.DefaultIfEmpty()
             join customer in _dbContext.Customers.AsNoTracking()
                 on booking.CustomerId equals customer.UserId into customerGroup
             from customer in customerGroup.DefaultIfEmpty()
@@ -69,7 +73,8 @@ public class DriverPortalController : Controller
                 PickupLongitude = booking.PickupLongitude,
                 StartDate = booking.Startdate,
                 EndDate = booking.Enddate,
-                BookingStatus = booking.BookingStatus ?? "Scheduled"
+                BookingStatus = booking.BookingStatus ?? "Scheduled",
+                TripStatus = trip != null ? trip.TripStatus.ToString() : null
             }).ToListAsync();
 
         var model = new DriverDashboardViewModel
@@ -102,6 +107,8 @@ public class DriverPortalController : Controller
 
         var availability = await _driverManager.GetDriverAvailabilityAsync(driver.DriverId);
         var bookings = await _bookingManager.GetBookingsByDriverIdAsync(driver.DriverId);
+        var trips = await _tripManager.GetTripsByDriverIdAsync(driver.DriverId);
+        var tripLookup = trips.ToDictionary(t => t.BookingId, t => t.TripStatus, EqualityComparer<int>.Default);
 
         var availabilityItems = availability.Select(a => new DriverAvailabilityItemViewModel
         {
@@ -124,7 +131,8 @@ public class DriverPortalController : Controller
                 EndDate = booking.Enddate,
                 PickupDateTime = booking.PickupDateTime,
                 PickupLocationLabel = booking.PickupLocationLabel ?? booking.PickupLocationName ?? booking.PickupAddress ?? "Pickup location",
-                BookingStatus = booking.BookingStatus ?? "Pending"
+                BookingStatus = booking.BookingStatus ?? "Pending",
+                TripStatus = tripLookup.TryGetValue(booking.BookingId, out var tripStatus) ? tripStatus : null
             });
         }
 
@@ -171,7 +179,8 @@ public class DriverPortalController : Controller
                     PickupLocationLabel = b.PickupLocationLabel,
                     StartDate = b.StartDate,
                     EndDate = b.EndDate,
-                    BookingStatus = b.BookingStatus
+                    BookingStatus = b.BookingStatus,
+                    TripStatus = b.TripStatus
                 })
                 .ToList()
         };
@@ -205,32 +214,31 @@ public class DriverPortalController : Controller
             return Forbid();
         }
 
-        var booking = await _bookingManager.GetBookingByIdAsync(id);
+        var booking = await _dbContext.Bookings.AsNoTracking()
+            .Include(b => b.Trip)
+            .Include(b => b.Car)
+            .Include(b => b.Customer)
+            .FirstOrDefaultAsync(b => b.BookingId == id);
         if (booking == null || booking.DriverId != driver.DriverId)
         {
             return NotFound();
         }
 
-        var car = await _carManager.GetCarByIdAsync(booking.CarId);
-        var customer = await _customerManager.GetCustomerById(booking.CustomerId);
-
-        var lastPing = await _dbContext.DriverLocationPings.AsNoTracking()
-            .Where(p => p.BookingId == booking.BookingId)
-            .OrderByDescending(p => p.CreatedAt)
-            .FirstOrDefaultAsync();
+        var tripStatus = booking.Trip?.TripStatus.ToString() ?? "Assigned";
 
         var model = new DriverBookingDetailsViewModel
         {
             BookingId = booking.BookingId,
-            BookingStatus = booking.BookingStatus,
-            CarName = car?.ModelName ?? "Vehicle",
-            CarPlate = car?.PlateNumber ?? "N/A",
-            CustomerName = customer?.Name ?? "Customer",
+            BookingStatus = booking.BookingStatus ?? string.Empty,
+            TripStatus = tripStatus,
+            CarName = booking.Car?.ModelName ?? "Vehicle",
+            CarPlate = booking.Car?.PlateNumber ?? "N/A",
+            CustomerName = booking.Customer?.Name ?? "Customer",
             PickupLocationLabel = booking.PickupLocationLabel ?? booking.PickupAddress ?? "Pickup pin",
             PickupLatitude = booking.PickupLatitude,
             PickupLongitude = booking.PickupLongitude,
-            DriverLatitude = lastPing != null ? (double?)lastPing.Latitude : null,
-            DriverLongitude = lastPing != null ? (double?)lastPing.Longitude : null,
+            DriverLatitude = booking.Trip?.LastDriverLatitude != null ? (double?)booking.Trip.LastDriverLatitude : null,
+            DriverLongitude = booking.Trip?.LastDriverLongitude != null ? (double?)booking.Trip.LastDriverLongitude : null,
             PickupDateTime = booking.PickupDateTime,
             DriverCode = driver.DriverCode,
             DriverId = driver.DriverId
@@ -242,6 +250,41 @@ public class DriverPortalController : Controller
         return View("~/Views/DriverPortal/BookingDetails.cshtml", model);
     }
 
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> StartTracking(int bookingId)
+    {
+        return await HandleTripActionAsync(bookingId, driverId => _tripManager.StartTrackingAsync(bookingId, driverId));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> MarkArrived(int bookingId)
+    {
+        return await HandleTripActionAsync(bookingId, driverId => _tripManager.MarkArrivedAsync(bookingId, driverId));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> StartTrip(int bookingId)
+    {
+        return await HandleTripActionAsync(bookingId, driverId => _tripManager.StartTripAsync(bookingId, driverId));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CompleteTrip(int bookingId)
+    {
+        return await HandleTripActionAsync(bookingId, driverId => _tripManager.CompleteTripAsync(bookingId, driverId));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CancelTrip(int bookingId, string? reason)
+    {
+        return await HandleTripActionAsync(bookingId, driverId => _tripManager.CancelTripAsync(bookingId, driverId, reason));
+    }
+
     private async Task<DriverDto?> GetCurrentDriverAsync()
     {
         var user = await _userManager.GetUserAsync(User);
@@ -251,6 +294,33 @@ public class DriverPortalController : Controller
         }
 
         return await _driverManager.GetDriverByUserIdAsync(user.Id);
+    }
+
+    private async Task<IActionResult> HandleTripActionAsync(int bookingId, Func<int, Task<TripActionResult>> action)
+    {
+        var driver = await GetCurrentDriverAsync();
+        if (driver == null)
+        {
+            return Forbid();
+        }
+
+        var result = await action(driver.DriverId);
+        if (!result.Success)
+        {
+            if (result.Error == TripActionError.Forbidden)
+            {
+                return Forbid();
+            }
+
+            if (result.Error == TripActionError.NotFound)
+            {
+                return NotFound();
+            }
+
+            TempData["TripError"] = result.Message;
+        }
+
+        return RedirectToAction(nameof(BookingDetails), new { id = bookingId });
     }
 
     private static bool IsAvailabilityOnDate(DriverAvailabilityItemViewModel availability, DateOnly date, DateTime dayStart, DateTime dayEnd)

--- a/RentACar.Web/Hubs/DriverTrackingHub.cs
+++ b/RentACar.Web/Hubs/DriverTrackingHub.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.SignalR;
+using RentACar.Application.Managers;
 using RentACar.Core.Entities;
 using RentACar.Core.Repositories;
 using RentACar.Infrastructure.Data;
@@ -14,17 +15,20 @@ public class DriverTrackingHub : Hub
 {
     private readonly IDriverRepository _driverRepository;
     private readonly IBookingRepository _bookingRepository;
+    private readonly TripManager _tripManager;
     private readonly RentACarDbContext _dbContext;
     private readonly UserManager<IdentityUser> _userManager;
 
     public DriverTrackingHub(
         IDriverRepository driverRepository,
         IBookingRepository bookingRepository,
+        TripManager tripManager,
         RentACarDbContext dbContext,
         UserManager<IdentityUser> userManager)
     {
         _driverRepository = driverRepository;
         _bookingRepository = bookingRepository;
+        _tripManager = tripManager;
         _dbContext = dbContext;
         _userManager = userManager;
     }
@@ -67,6 +71,17 @@ public class DriverTrackingHub : Hub
              || booking.BookingStatus.Equals("cancelled", StringComparison.OrdinalIgnoreCase)))
         {
             throw new HubException("Booking not active");
+        }
+
+        var tripResult = await _tripManager.UpdateDriverLocationAsync(
+            booking.BookingId,
+            driver.DriverId,
+            (decimal)latitude,
+            (decimal)longitude,
+            timestamp);
+        if (!tripResult.Success)
+        {
+            throw new HubException(tripResult.Message);
         }
 
         var ping = new DriverLocationPing

--- a/RentACar.Web/Models/DriverPortalViewModels.cs
+++ b/RentACar.Web/Models/DriverPortalViewModels.cs
@@ -28,6 +28,7 @@ public class DriverBookingDetailsViewModel
 {
     public int BookingId { get; set; }
     public string BookingStatus { get; set; } = string.Empty;
+    public string TripStatus { get; set; } = string.Empty;
     public string CarName { get; set; } = string.Empty;
     public string CarPlate { get; set; } = string.Empty;
     public string CustomerName { get; set; } = string.Empty;
@@ -51,6 +52,7 @@ public class DriverPortalBookingViewModel
     public DateOnly StartDate { get; set; }
     public DateOnly EndDate { get; set; }
     public string BookingStatus { get; set; } = string.Empty;
+    public string? TripStatus { get; set; }
 }
 
 public class DriverScheduleDayViewModel
@@ -73,6 +75,7 @@ public class DriverScheduleBookingItemViewModel
     public DateTime? PickupDateTime { get; set; }
     public string PickupLocationLabel { get; set; } = string.Empty;
     public string BookingStatus { get; set; } = string.Empty;
+    public string? TripStatus { get; set; }
 }
 
 public class DriverAvailabilityItemViewModel

--- a/RentACar.Web/Program.cs
+++ b/RentACar.Web/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddScoped<IBlacklistRepository, BlacklistRepository>();
 builder.Services.AddScoped<IPromocodeRepository, PromocodeRepository>();
 builder.Services.AddScoped<IPaymentMethodRepository, PaymentMethodRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
+builder.Services.AddScoped<ITripRepository, TripRepository>();
 builder.Services.AddHttpClient<IEmailService, MailjetEmailService>();
 builder.Services.AddHttpClient<RentACar.Application.Services.IStripePaymentService, RentACar.Application.Services.StripePaymentService>(client =>
 {
@@ -101,6 +102,7 @@ builder.Services.AddScoped<BookingManager>();
 builder.Services.AddScoped<PaymentManager>();
 builder.Services.AddScoped<EmailManager>();
 builder.Services.AddScoped<AuditLogManager>();
+builder.Services.AddScoped<TripManager>();
 
 // // ✅ HTTPS redirection
 // builder.Services.AddHttpsRedirection(options =>

--- a/RentACar.Web/Views/DriverPortal/BookingDetails.cshtml
+++ b/RentACar.Web/Views/DriverPortal/BookingDetails.cshtml
@@ -5,18 +5,24 @@
     var pickupLng = Model.PickupLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
     var driverLat = Model.DriverLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
     var driverLng = Model.DriverLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
-    var statusLabel = Model.BookingStatus?.ToLowerInvariant() switch
+    var statusLabel = Model.TripStatus?.ToLowerInvariant() switch
     {
+        "assigned" => "Assigned",
         "pending" => "Scheduled",
         "booked" => "Scheduled",
+        "ontheway" => "On the way",
         "on the way" => "On the way",
         "on_the_way" => "On the way",
         "arrived" => "Arrived",
+        "intrip" => "In Trip",
         "in trip" => "In Trip",
         "in_trip" => "In Trip",
         "completed" => "Completed",
-        _ => string.IsNullOrWhiteSpace(Model.BookingStatus) ? "Scheduled" : Model.BookingStatus
+        "cancelled" => "Cancelled",
+        _ => string.IsNullOrWhiteSpace(Model.TripStatus) ? "Assigned" : Model.TripStatus
     };
+    var normalizedTripStatus = (Model.TripStatus ?? "Assigned").Trim().ToLowerInvariant();
+    var isTerminal = normalizedTripStatus == "completed" || normalizedTripStatus == "cancelled";
 }
 <style>
     .glass-card {
@@ -131,11 +137,71 @@
                     Trip Actions
                 </h3>
                 <div class="flex flex-col gap-3">
-                    <button id="startTrip" class="h-12 rounded-xl bg-primary text-background-dark text-sm font-black tracking-wider shadow-[0_0_20px_-5px_#f4c325] hover:brightness-110 transition-all">Start Trip</button>
-                    <button id="arrivedButton" class="h-12 rounded-xl border border-white/10 text-white font-semibold hover:bg-white/10 transition-all">I Arrived</button>
-                    <button id="completeTrip" class="h-12 rounded-xl border border-green-500/40 text-green-400 font-semibold hover:bg-green-500/10 transition-all">Complete Trip</button>
+                    @if (normalizedTripStatus == "assigned")
+                    {
+                        <form method="post" asp-action="StartTracking">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="bookingId" value="@Model.BookingId" />
+                            <button class="h-12 w-full rounded-xl bg-primary text-background-dark text-sm font-black tracking-wider shadow-[0_0_20px_-5px_#f4c325] hover:brightness-110 transition-all">
+                                Start Tracking / On the way
+                            </button>
+                        </form>
+                    }
+                    else if (normalizedTripStatus == "ontheway" || normalizedTripStatus == "on_the_way" || normalizedTripStatus == "on the way")
+                    {
+                        <form method="post" asp-action="MarkArrived">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="bookingId" value="@Model.BookingId" />
+                            <button class="h-12 w-full rounded-xl border border-white/10 text-white font-semibold hover:bg-white/10 transition-all">I Arrived</button>
+                        </form>
+                    }
+                    else if (normalizedTripStatus == "arrived")
+                    {
+                        <form method="post" asp-action="StartTrip">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="bookingId" value="@Model.BookingId" />
+                            <button class="h-12 w-full rounded-xl bg-primary text-background-dark text-sm font-black tracking-wider shadow-[0_0_20px_-5px_#f4c325] hover:brightness-110 transition-all">
+                                Start Trip
+                            </button>
+                        </form>
+                    }
+                    else if (normalizedTripStatus == "intrip" || normalizedTripStatus == "in_trip" || normalizedTripStatus == "in trip")
+                    {
+                        <form method="post" asp-action="CompleteTrip">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="bookingId" value="@Model.BookingId" />
+                            <button class="h-12 w-full rounded-xl border border-green-500/40 text-green-400 font-semibold hover:bg-green-500/10 transition-all">Complete Trip</button>
+                        </form>
+                    }
+                    else if (normalizedTripStatus == "completed")
+                    {
+                        <button class="h-12 rounded-xl border border-green-500/40 text-green-400 font-semibold opacity-70 cursor-not-allowed" disabled>
+                            Trip Completed
+                        </button>
+                    }
+                    else if (normalizedTripStatus == "cancelled")
+                    {
+                        <button class="h-12 rounded-xl border border-red-500/40 text-red-400 font-semibold opacity-70 cursor-not-allowed" disabled>
+                            Trip Cancelled
+                        </button>
+                    }
                 </div>
-                <div id="statusMessage" class="text-xs text-white/60"></div>
+                @if (!isTerminal)
+                {
+                    <form method="post" asp-action="CancelTrip" class="mt-2">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="bookingId" value="@Model.BookingId" />
+                        <input type="text" name="reason" placeholder="Cancel reason (optional)"
+                               class="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80 placeholder:text-white/40" />
+                        <button class="mt-2 h-10 w-full rounded-xl border border-red-500/30 text-red-400 font-semibold hover:bg-red-500/10 transition-all">
+                            Cancel Trip
+                        </button>
+                    </form>
+                }
+                @if (TempData["TripError"] != null)
+                {
+                    <div id="statusMessage" class="text-xs text-red-400">@TempData["TripError"]</div>
+                }
             </div>
         </div>
 
@@ -176,7 +242,6 @@
     const initialDriverLng = '@driverLng';
 
     const statusPill = document.getElementById('statusPill');
-    const statusMessage = document.getElementById('statusMessage');
     const trackingStatus = document.getElementById('trackingStatus');
     const trackingError = document.getElementById('trackingError');
     const retryTracking = document.getElementById('retryTracking');
@@ -199,26 +264,6 @@
     let pickupMarker;
     let directionsService;
     let directionsRenderer;
-
-    function formatStatusLabel(status) {
-        switch (status.toLowerCase()) {
-            case 'pending':
-            case 'booked':
-                return 'Scheduled';
-            case 'on the way':
-            case 'on_the_way':
-                return 'On the way';
-            case 'arrived':
-                return 'Arrived';
-            case 'in trip':
-            case 'in_trip':
-                return 'In Trip';
-            case 'completed':
-                return 'Completed';
-            default:
-                return status;
-        }
-    }
 
     function haversineMeters(a, b) {
         if (!a || !b) return 0;
@@ -353,24 +398,6 @@
         gpsSignal.textContent = 'GPS: Stopped';
     }
 
-    async function updateBookingStatus(status) {
-        const response = await fetch(`/api/driver/bookings/${bookingId}/status`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ status })
-        });
-
-        if (!response.ok) {
-            const text = await response.text();
-            statusMessage.textContent = `Unable to update status: ${text}`;
-            return;
-        }
-
-        const label = formatStatusLabel(status);
-        statusPill.textContent = label;
-        statusMessage.textContent = `Status updated to ${label}.`;
-    }
-
     function updateDriverMarker(position) {
         if (!map || !driverMarker) return;
         driverMarker.setPosition(position);
@@ -446,19 +473,9 @@
     document.getElementById('stopTracking').addEventListener('click', stopWatching);
     retryTracking.addEventListener('click', startWatching);
 
-    document.getElementById('startTrip').addEventListener('click', async () => {
-        await updateBookingStatus('On the way');
-        startWatching();
-    });
-
-    document.getElementById('arrivedButton').addEventListener('click', async () => {
-        await updateBookingStatus('Arrived');
-    });
-
-    document.getElementById('completeTrip').addEventListener('click', async () => {
-        await updateBookingStatus('Completed');
-        stopWatching();
-    });
+    if (statusPill && statusPill.textContent.toLowerCase().includes('on the way')) {
+        updateTrackingStatus('Live: Tracking available');
+    }
 </script>
 
 @if (!string.IsNullOrWhiteSpace(ViewBag.GoogleMapsKey))

--- a/RentACar.Web/Views/DriverPortal/Schedule.cshtml
+++ b/RentACar.Web/Views/DriverPortal/Schedule.cshtml
@@ -437,10 +437,26 @@
     function getStatusClass(status) {
         if (!status) return 'status-default';
         const normalized = status.toLowerCase();
-        if (normalized.includes('confirm')) return 'status-confirmed';
+        if (normalized.includes('completed')) return 'status-confirmed';
         if (normalized.includes('cancel')) return 'status-cancelled';
-        if (normalized.includes('pending') || normalized.includes('schedule')) return 'status-pending';
+        if (normalized.includes('on the way') || normalized.includes('ontheway') || normalized.includes('arrived') || normalized.includes('intrip') || normalized.includes('in trip')) {
+            return 'status-confirmed';
+        }
+        if (normalized.includes('pending') || normalized.includes('schedule') || normalized.includes('assigned')) return 'status-pending';
         return 'status-default';
+    }
+
+    function formatStatusLabel(status) {
+        if (!status) return status;
+        const normalized = status.toLowerCase();
+        if (normalized === 'ontheway') return 'On the way';
+        if (normalized === 'intrip') return 'In Trip';
+        return status;
+    }
+
+    function getDisplayStatus(booking) {
+        const status = booking.tripStatus || booking.bookingStatus || 'Pending';
+        return formatStatusLabel(status);
     }
 
     function getBookingsForDate(date) {
@@ -554,7 +570,7 @@
                         <p class="text-xs text-white/50">${booking.customerName || 'Customer'} • ${booking.pickupLocationLabel || 'Pickup location'}</p>
                         <p class="text-xs text-white/40">${booking.startDate} → ${booking.endDate}</p>
                     </div>
-                    <span class="status-badge ${getStatusClass(booking.bookingStatus)}">${booking.bookingStatus || 'Pending'}</span>
+                    <span class="status-badge ${getStatusClass(getDisplayStatus(booking))}">${getDisplayStatus(booking)}</span>
                 </div>
             `;
 
@@ -565,8 +581,8 @@
 
     function openBookingSheet(booking) {
         bookingSheetTitle.textContent = `Booking #${booking.bookingId}`;
-        bookingSheetStatus.textContent = booking.bookingStatus || 'Pending';
-        bookingSheetStatus.className = `status-badge ${getStatusClass(booking.bookingStatus)}`;
+        bookingSheetStatus.textContent = getDisplayStatus(booking);
+        bookingSheetStatus.className = `status-badge ${getStatusClass(getDisplayStatus(booking))}`;
         bookingSheetCustomer.textContent = booking.customerName || 'Customer';
         bookingSheetFrom.textContent = booking.pickupLocationLabel || 'Pickup location';
         bookingSheetTo.textContent = 'Dropoff not specified';


### PR DESCRIPTION
### Motivation

- Introduce a first-class `Trip` model to represent driver execution of a `Booking`, persist lifecycle state and last-known driver location, and make driver actions durable. 
- Enforce correct status transitions and driver ownership so DriverPortal actions map to backend state and the UI reflects real DB state.

### Description

- Add domain model and mapping: created `Trip` entity and `TripStatus` enum and wired EF Core configuration in `RentACarDbContext` with a unique index on `BookingId` and `TripStatus` string conversion.  
- Implement persistence layer: added `ITripRepository` and `TripRepository` using EF Core with `Include` for `Booking`/`Driver` and `AsNoTracking` for list queries.  
- Implement business logic: added `TripManager` (application layer) that performs idempotent trip creation, validates lifecycle transitions (Assigned → OnTheWay → Arrived → InTrip → Completed / Cancelled), enforces driver ownership, updates `UpdatedAt` and timestamp fields, updates last-known driver location via `UpdateDriverLocationAsync`, and logs audit events.  
- DTOs & mapping: added `TripDto`, `TripActionResult` and `TripProfile` (AutoMapper) to shape API/manager responses.  
- Wire into web layer and realtime: registered `ITripRepository` and `TripManager` in `Program.cs`, updated `DriverLocationController` and `DriverTrackingHub` to call `TripManager.UpdateDriverLocationAsync`, and updated `DriverPortalController` to include trip info and expose POST actions (`StartTracking`, `MarkArrived`, `StartTrip`, `CompleteTrip`, `CancelTrip`) that persist state with anti-forgery protection.  
- UI changes: updated `BookingDetails` and `Schedule` views to show trip status badges and render action buttons as POST forms that reflect and persist the trip lifecycle; added cancel form and improved schedule status mapping.  

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc8d3eb048320899a4b5f6b92a12f)